### PR TITLE
feat: queue.sh done 時に GitHub Issue を自動クローズ

### DIFF
--- a/scripts/queue.sh
+++ b/scripts/queue.sh
@@ -150,6 +150,18 @@ cmd_done() {
   atomic_write "$updated"
   release_lock
   echo "OK: $slug → DONE"
+
+  # notes から GitHub Issue 番号を抽出して自動クローズ
+  if command -v gh >/dev/null 2>&1; then
+    local issue_num
+    issue_num=$(jq -r --arg s "$slug" '.tasks[] | select(.slug == $s) | .notes // ""' "$QUEUE_FILE" \
+      | grep -oE '#[0-9]+' | head -1 | tr -d '#')
+    if [[ -n "$issue_num" ]]; then
+      gh issue close "$issue_num" --comment "✅ ${agent}: ${slug} 完了 — ${msg}" 2>/dev/null && \
+        echo "OK: Issue #$issue_num closed" || \
+        echo "WARN: Issue #$issue_num close failed (ignored)" >&2
+    fi
+  fi
 }
 
 # ---------- コマンド: handoff ----------


### PR DESCRIPTION
## Summary
- `scripts/queue.sh done` 実行時、タスクの `notes` から `#N` を抽出して `gh issue close` を自動実行
- クローズ時にエージェント名と完了メッセージをコメントとして残す
- `gh` CLI が無い環境ではスキップ（エラーにならない）

## 動作例
```
scripts/queue.sh done slack-design Alex "ADR作成完了"
→ OK: slack-design → DONE
→ OK: Issue #2 closed  （notesに "GitHub Issue #2" があるため）
```

## Test plan
- [x] Sprint-1 の5件のIssueを手動クローズで動作確認済み
- [ ] 次スプリントで `done` コマンド経由の自動クローズを実運用テスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)