### PR TITLE
feat(lessons): add status field to track improvement lifecycle

### DIFF
--- a/scripts/lessons.sh
+++ b/scripts/lessons.sh
@@ -187,7 +187,18 @@ _do_set_status() {
     --arg id         "$target_id" \
     --arg status     "$new_status" \
     --arg updated_at "$updated_at" \
-    '.lessons |= map(if .id == $id then .status = $status | .updated_at = $updated_at else . end)' \
+    '.lessons |= map(
+      if .id == $id then
+        {
+          id, project, sprint, category, type,
+          severity_score, frequency_score, priority_score,
+          description, evidence, action,
+          issue_url, status: $status,
+          supersedes, tags,
+          created_at, updated_at: $updated_at
+        }
+      else . end
+    )' \
     <<< "$existing")
 
   tmp=$(mktemp "${LESSONS_FILE}.tmp.XXXXXX")

--- a/scripts/lessons.sh
+++ b/scripts/lessons.sh
@@ -11,10 +11,13 @@
 #     --description "<description>" \
 #     --action "<action>" \
 #     [--type <failure|success|observation>] \
+#     [--status <proposed|issue_created|implemented|verified|dismissed>] \
 #     [--evidence "<evidence1>" --evidence "<evidence2>" ...] \
 #     [--tags "<tag1>" --tags "<tag2>" ...] \
 #     [--issue-url <url>] \
 #     [--supersedes <id>]
+#
+#   lessons.sh set-status <id> <proposed|issue_created|implemented|verified|dismissed>
 #
 # 環境変数:
 #   LESSONS_FILE   lessons ファイルパス (default: ~/.claude/_lessons.json)
@@ -31,9 +34,13 @@ LOCK_TIMEOUT="${LOCK_TIMEOUT:-10}"
 
 usage() {
   cat >&2 <<'EOF'
-Usage: lessons.sh add [OPTIONS]
+Usage: lessons.sh <command> [OPTIONS]
 
-Options:
+Commands:
+  add            新しい lesson を追加する
+  set-status     既存 lesson のステータスを更新する
+
+add options:
   --project      プロジェクト名 (必須)
   --sprint       スプリント識別子 例: sprint-02 (必須)
   --category     カテゴリ: planning|implementation|qa|communication|tooling|process|architecture (必須)
@@ -42,11 +49,16 @@ Options:
   --description  何が起きたか・何を学んだか (必須)
   --action       次回取るべきアクション (必須)
   --type         failure|success|observation (省略時: failure)
+  --status       proposed|issue_created|implemented|verified|dismissed (省略時: proposed)
   --evidence     観察の根拠 (複数指定可)
   --tags         自由タグ (複数指定可)
   --issue-url    対応 GitHub Issue の URL
   --supersedes   改訂対象の旧 lesson ID
   --help         このヘルプを表示
+
+set-status args:
+  <id>           lesson ID (必須)
+  <status>       proposed|issue_created|implemented|verified|dismissed (必須)
 EOF
   exit 1
 }
@@ -65,9 +77,13 @@ if [[ "$CMD" == "--help" || "$CMD" == "-h" || -z "$CMD" ]]; then
   usage
 fi
 
-if [[ "$CMD" != "add" ]]; then
-  die "unknown command: '$CMD'. Only 'add' is supported."
+if [[ "$CMD" != "add" && "$CMD" != "set-status" ]]; then
+  die "unknown command: '$CMD'. Use 'add' or 'set-status'."
 fi
+
+# set-status の場合は positional args のみ保持して add 用パース処理をスキップ
+SET_STATUS_ID="${1:-}"
+SET_STATUS_VAL="${2:-}"
 
 PROJECT=""
 SPRINT=""
@@ -77,11 +93,13 @@ FREQUENCY=""
 DESCRIPTION=""
 ACTION=""
 TYPE="failure"
+STATUS="proposed"
 ISSUE_URL="null"
 SUPERSEDES="null"
 EVIDENCE_ITEMS=()
 TAG_ITEMS=()
 
+if [[ "$CMD" == "add" ]]; then
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --project)     PROJECT="$2";      shift 2 ;;
@@ -92,6 +110,7 @@ while [[ $# -gt 0 ]]; do
     --description) DESCRIPTION="$2";  shift 2 ;;
     --action)      ACTION="$2";       shift 2 ;;
     --type)        TYPE="$2";         shift 2 ;;
+    --status)      STATUS="$2";       shift 2 ;;
     --issue-url)   ISSUE_URL="\"$2\""; shift 2 ;;
     --supersedes)  SUPERSEDES="\"$2\""; shift 2 ;;
     --evidence)    EVIDENCE_ITEMS+=("$2"); shift 2 ;;
@@ -100,41 +119,42 @@ while [[ $# -gt 0 ]]; do
     *) die "unknown option: '$1'" ;;
   esac
 done
+fi
 
-# ---------- バリデーション ----------
+# ---------- バリデーション (add のみ) ----------
 
-[[ -n "$PROJECT" ]]     || die "--project is required"
-[[ -n "$SPRINT" ]]      || die "--sprint is required"
-[[ -n "$CATEGORY" ]]    || die "--category is required"
-[[ -n "$SEVERITY" ]]    || die "--severity is required"
-[[ -n "$FREQUENCY" ]]   || die "--frequency is required"
-[[ -n "$DESCRIPTION" ]] || die "--description is required"
-[[ -n "$ACTION" ]]      || die "--action is required"
+if [[ "$CMD" == "add" ]]; then
+  [[ -n "$PROJECT" ]]     || die "--project is required"
+  [[ -n "$SPRINT" ]]      || die "--sprint is required"
+  [[ -n "$CATEGORY" ]]    || die "--category is required"
+  [[ -n "$SEVERITY" ]]    || die "--severity is required"
+  [[ -n "$FREQUENCY" ]]   || die "--frequency is required"
+  [[ -n "$DESCRIPTION" ]] || die "--description is required"
+  [[ -n "$ACTION" ]]      || die "--action is required"
 
-# sprint パターン検証
-[[ "$SPRINT" =~ ^sprint-[0-9]+$ ]] \
-  || die "--sprint must match 'sprint-NNN' (e.g. sprint-02), got: '$SPRINT'"
+  [[ "$SPRINT" =~ ^sprint-[0-9]+$ ]] \
+    || die "--sprint must match 'sprint-NNN' (e.g. sprint-02), got: '$SPRINT'"
 
-# category 検証
-VALID_CATEGORIES="planning implementation qa communication tooling process architecture"
-echo "$VALID_CATEGORIES" | tr ' ' '\n' | grep -qx "$CATEGORY" \
-  || die "--category must be one of: $VALID_CATEGORIES, got: '$CATEGORY'"
+  VALID_CATEGORIES="planning implementation qa communication tooling process architecture"
+  echo "$VALID_CATEGORIES" | tr ' ' '\n' | grep -qx "$CATEGORY" \
+    || die "--category must be one of: $VALID_CATEGORIES, got: '$CATEGORY'"
 
-# severity / frequency 数値範囲検証
-[[ "$SEVERITY" =~ ^[1-3]$ ]] \
-  || die "--severity must be 1, 2, or 3, got: '$SEVERITY'"
-[[ "$FREQUENCY" =~ ^[1-3]$ ]] \
-  || die "--frequency must be 1, 2, or 3, got: '$FREQUENCY'"
+  [[ "$SEVERITY" =~ ^[1-3]$ ]] \
+    || die "--severity must be 1, 2, or 3, got: '$SEVERITY'"
+  [[ "$FREQUENCY" =~ ^[1-3]$ ]] \
+    || die "--frequency must be 1, 2, or 3, got: '$FREQUENCY'"
 
-# type 検証
-[[ "$TYPE" =~ ^(failure|success|observation)$ ]] \
-  || die "--type must be failure, success, or observation, got: '$TYPE'"
+  [[ "$TYPE" =~ ^(failure|success|observation)$ ]] \
+    || die "--type must be failure, success, or observation, got: '$TYPE'"
 
-# description / action 最低文字数
-[[ ${#DESCRIPTION} -ge 10 ]] \
-  || die "--description must be at least 10 characters"
-[[ ${#ACTION} -ge 5 ]] \
-  || die "--action must be at least 5 characters"
+  [[ "$STATUS" =~ ^(proposed|issue_created|implemented|verified|dismissed)$ ]] \
+    || die "--status must be proposed|issue_created|implemented|verified|dismissed, got: '$STATUS'"
+
+  [[ ${#DESCRIPTION} -ge 10 ]] \
+    || die "--description must be at least 10 characters"
+  [[ ${#ACTION} -ge 5 ]] \
+    || die "--action must be at least 5 characters"
+fi
 
 # ファイル存在確認（初期化済みか）
 [[ -f "$LESSONS_FILE" ]] \
@@ -149,6 +169,34 @@ command -v jq >/dev/null 2>&1 \
 
 # flock が使えない環境（macOS では util-linux の flock が無い場合がある）への対応:
 # lockfile コマンドまたは mkdir を fallback として使う
+_do_set_status() {
+  local target_id="$1" new_status="$2"
+  local existing updated tmp updated_at
+
+  [[ -f "$LESSONS_FILE" ]] || die "$LESSONS_FILE does not exist."
+  [[ "$new_status" =~ ^(proposed|issue_created|implemented|verified|dismissed)$ ]] \
+    || die "invalid status: '$new_status'"
+
+  existing=$(cat "$LESSONS_FILE")
+
+  jq -e --arg id "$target_id" '.lessons[] | select(.id == $id)' <<< "$existing" > /dev/null \
+    || die "lesson not found: '$target_id'"
+
+  updated_at=$(date -u +"%Y-%m-%dT%H:%M:%S+0000")
+  updated=$(jq \
+    --arg id         "$target_id" \
+    --arg status     "$new_status" \
+    --arg updated_at "$updated_at" \
+    '.lessons |= map(if .id == $id then .status = $status | .updated_at = $updated_at else . end)' \
+    <<< "$existing")
+
+  tmp=$(mktemp "${LESSONS_FILE}.tmp.XXXXXX")
+  echo "$updated" > "$tmp"
+  mv "$tmp" "$LESSONS_FILE"
+
+  echo "Updated $target_id: status → $new_status"
+}
+
 _do_add() {
   local existing next_seq id priority_score created_at evidence_json tags_json new_entry updated tmp
 
@@ -207,6 +255,7 @@ _do_add() {
     --argjson evidence "$evidence_json" \
     --argjson tags     "$tags_json" \
     --argjson issue_url "$ISSUE_URL" \
+    --arg status       "$STATUS" \
     --argjson supersedes "$SUPERSEDES" \
     --arg created_at   "$created_at" \
     '{
@@ -222,6 +271,7 @@ _do_add() {
       evidence:        $evidence,
       action:          $action,
       issue_url:       $issue_url,
+      status:          $status,
       supersedes:      $supersedes,
       tags:            $tags,
       created_at:      $created_at,
@@ -237,6 +287,31 @@ _do_add() {
 
   echo "$id"
 }
+
+# ---------- コマンド実行 ----------
+
+if [[ "$CMD" == "set-status" ]]; then
+  [[ -n "$SET_STATUS_ID" ]]  || die "set-status requires <id> argument"
+  [[ -n "$SET_STATUS_VAL" ]] || die "set-status requires <status> argument"
+
+  command -v jq >/dev/null 2>&1 || die "jq is not installed."
+  [[ -f "$LESSONS_FILE" ]]      || die "$LESSONS_FILE does not exist."
+
+  if command -v flock >/dev/null 2>&1; then
+    result=$(
+      (
+        flock -x -w "$LOCK_TIMEOUT" 200 || die "lock timeout (${LOCK_TIMEOUT}s). Another process may be writing."
+        _do_set_status "$SET_STATUS_ID" "$SET_STATUS_VAL"
+      ) 200>"$LOCK_FILE"
+    )
+  else
+    echo "WARN: flock not available. Running without file lock." >&2
+    result=$(_do_set_status "$SET_STATUS_ID" "$SET_STATUS_VAL")
+  fi
+
+  echo "$result"
+  exit 0
+fi
 
 # flock が使えるか確認（macOS の util-linux 版）
 if command -v flock >/dev/null 2>&1; then

--- a/templates/_lessons.json
+++ b/templates/_lessons.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "1.0.0",
+  "schema_version": "1.1.0",
   "lessons": [
     {
       "id": "agent-crew-sprint-00-tooling-001",

--- a/templates/_lessons.json
+++ b/templates/_lessons.json
@@ -14,6 +14,7 @@
       "evidence": ["テンプレートファイル初期化"],
       "action": "このエントリは削除して実際の lesson を追記してください。",
       "issue_url": null,
+      "status": "proposed",
       "supersedes": null,
       "tags": ["template", "example"],
       "created_at": "2026-04-21T00:00:00+0900",


### PR DESCRIPTION
_lessons.json テンプレートに status フィールドを追加し、
lessons.sh に set-status サブコマンドを実装。
proposed → issue_created → implemented → verified → dismissed
のライフサイクルで改善が宙ぶらりんになる問題を解消する。

https://claude.ai/code/session_013kDgps36L3pE9y1FdSrfCu