### PR TITLE
fix: lessons から agent .md へ禁止パターンを自動提案 (2026-04-26)

### DIFF
--- a/.claude/agents/engineer-go.md
+++ b/.claude/agents/engineer-go.md
@@ -325,3 +325,61 @@ Yuki へは `BLOCKED` ステータスとともにキューの notes へ詳細を
   - 外部 API への連続リクエスト
   - `git push`（ネットワーク依存・長時間化リスク）
 - Bash コマンドには原則 `timeout 30 <command>` を付与する（長時間処理を除く）
+
+---
+
+## 禁止パターン（lessons より自動提案）
+
+> このセクションは `scripts/propose-lesson-rules.sh` によって生成されました。
+> オーナーのレビュー後にマージしてください。
+> 最終更新: 2026-04-26
+
+### agent-crew-sprint-05-reliability-001
+- **lesson**: スマホRemote Controlのスリープにより接続が切断され、Soraが内部エラーで落ちた。深夜セッション（alex-bash-impl完了）と朝セッション（alex-bash-qa実施）の間に約8時間のブレイクが発生した。
+- **禁止行動**: #39（セッション中断検出機構）の実装を Sprint-06 で行う。検出後はSlackまたはSTDOUTに通知することで作業再開を促す。
+- **priority**: 4 / sprint: sprint-05
+
+### agent-crew-sprint-05-tooling-001
+- **lesson**: Alexへの Bash 付与後、token-opt-designではstart/doneを自己発行できた。しかしsession-interrupt-designはサブエージェントコンテキストで実行されBashが利用できなかった。Bash付与
+- **禁止行動**: Alexがサブエージェントとして実行される場合のBash利用可否を次スプリントで明示的に検証し、結果をarchitect.mdに注意事項として記載する。
+- **priority**: 4 / sprint: sprint-05
+
+### agent-crew-sprint-08-tooling-001
+- **lesson**: Bash の ${4:-{}} 構文で、デフォルト値に {} を使うとシェルが } を誤解釈し JSON が破損する。set -e + || true の組み合わせでサイレントに失敗し、Sprint-08 の大半のシグナルが _signal
+- **禁止行動**: 設計書に含まれる Bash コードサンプルは Sora が bash -n または実行でバリデーションを行う。${...} 展開を含むコードは特に要注意。サブシェル内で set +e を先行させ jq -cn --argjson を使ってデフォルト値を渡すパターンを標準とする。
+- **priority**: 9 / sprint: sprint-08
+
+### agent-crew-sprint-08-reliability-001
+- **lesson**: engineer-go サブエージェントに長い実装指示（queue.sh 全体 + 詳細指示）を渡したとき、Agent tool が [Tool result missing due to internal error] で無応答停止した。
+- **禁止行動**: サブエージェントへの実装指示は 2,000 トークン以下を目安に分割する。queue.sh 全体を渡さず関係する関数部分のみ抜粋する。complexity L タスクは 2つの complexity M に分割することを検討する。
+- **priority**: 6 / sprint: sprint-08
+
+### agent-crew-sprint-09-tooling-001
+- **lesson**: Sprint-08 の emit バグ修正後も _signals.jsonl ファイルが存在しない。queue.py では Python で正しく実装されたとの報告があるが、signals の書き込みが実際に機能しているか検証されていない。
+- **禁止行動**: 各スプリント開始後の最初のタスク完了時に Sora が _signals.jsonl の存在と内容を確認するスモークテストを QA チェックリストに追加する。
+- **priority**: 4 / sprint: sprint-09
+
+### agent-crew-sprint-11-reliability-001
+- **lesson**: 
+- **禁止行動**: Yuki は Riku の L タスクを1スプリント1件までに制限する計画ルールを追加。フォールバック手順を pm.md に明記。
+- **priority**: 4 / sprint: sprint-11
+
+### agent-crew-sprint-11-reliability-002
+- **lesson**: 
+- **禁止行動**: Sora のエージェント定義に「Bash 不可の場合は CHANGES_REQUESTED（REASON: BASH_UNAVAILABLE）を返す」を追加。
+- **priority**: 6 / sprint: sprint-11
+
+### agent-crew-sprint-12-reliability-001
+- **lesson**: Sprint-12 で Alex による investigate-engineer-go タスクが完了し、Issue #64（engineer-go 無応答停止）の根本原因仮説（仮説 A: コンテキストウィンドウ超過が最有力）・検出方法・対
+- **禁止行動**: Sprint-13 で engineer-go.md に「参照ファイル3件以下・200行超は limit/offset 使用」のルールを追記し、pm.md に委譲チェックリストを追記する。完了後に Issue #64 をクローズする。
+- **priority**: 6 / sprint: sprint-12
+
+### agent-crew-sprint-15-tooling-001
+- **lesson**: Sprint-15 開始直後、Bash コマンドが絶対パス（/Users/...）で拒否された。settings.json の permissions.allow の Bash パターンは相対パス形式のみ一致し、絶対パスでは権限拒否になる。
+- **禁止行動**: 
+- **priority**: 4 / sprint: sprint-15
+
+### agent-crew-sprint-15-tooling-002
+- **lesson**: Sprint-15 の retro フェーズで scripts/lessons.sh が permissions.allow に未登録であり、lesson 記録（lessons.sh add）が実行できなかった。
+- **禁止行動**: 
+- **priority**: 4 / sprint: sprint-15

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -267,3 +267,61 @@ Antigravity（SubagentStop hook 未対応）の場合：
 理由: [一文で説明]
 ---
 ```
+
+---
+
+## 禁止パターン（lessons より自動提案）
+
+> このセクションは `scripts/propose-lesson-rules.sh` によって生成されました。
+> オーナーのレビュー後にマージしてください。
+> 最終更新: 2026-04-26
+
+### agent-crew-sprint-05-process-001
+- **lesson**: PR作成時のTest Planチェックリスト確認漏れがオーナーに指摘された。sprint-04でも同じ指摘を受けており、2スプリント連続の繰り返し問題。PRテンプレートまたはRikuの完了基準にTest Plan確認が含まれていないことが根
+- **禁止行動**: PRテンプレートにTest Planチェックリスト確認を明示する。Rikuの実装完了チェックリストに「PR Test Planが記入されているか確認する」を追加する。
+- **priority**: 6 / sprint: sprint-05
+
+### agent-crew-sprint-05-process-002
+- **lesson**: スプリント完了後のコミット可否をオーナーに確認した。MEMORYにKeep going（介入最小化）と記録されているにもかかわらず確認が発生した。コミット判断基準がCLAUDE.mdまたはpm.mdに明文化されていないことが根因。
+- **禁止行動**: CLAUDE.mdまたはpm.mdに「スプリント完了後はオーナー確認なしにコミット・PR作成してよい（ブランチ: feat/sprint-XX-clean）」というルールを明記する。
+- **priority**: 4 / sprint: sprint-05
+
+### agent-crew-sprint-07-process-001
+- **lesson**: Sprint-07 完了後にレトロが実施されないまま Sprint-08 に突入した。Sprint-06 で「みゆきち自動起動を pm.md に明文化した」にもかかわらず Sprint-07 完了時に実行されなかった。振り返りが欠落すると 
+- **禁止行動**: pm.md または retro.md の完了基準に「スプリント完了時、Yuki は @retro を呼ぶ」を追加し、スプリント完了メッセージのテンプレートに @retro 呼び出しを含める。
+- **priority**: 6 / sprint: sprint-07
+
+### agent-crew-sprint-08-process-001
+- **lesson**: signals-qa タスクの summary が test のまま記録されており、QA の実施内容が不明。シグナルのバグが残ったまま QA APPROVED の形になっている。QA タスクで実際に動作確認が行われたかどうかが記録から判断で
+- **禁止行動**: QA タスクの notes に実際のテスト手順を明記し、Sora は手順を実行した結果を summary に記録することをルール化する。テスト実行なしの DONE は CHANGES_REQUESTED 扱いとする。
+- **priority**: 4 / sprint: sprint-08
+
+### agent-crew-sprint-09-process-001
+- **lesson**: engineer-go サブエージェントが複雑な実装タスクで Agent tool internal error により無応答停止する問題が Sprint-08 に続き Sprint-09 でも再発した。Sprint-08 retro の改
+- **禁止行動**: pm.md のスプリント計画手順に「complexity L タスクは M×2 に自動分割する」を明記する。engineer-go 起動前に実装指示のトークン数を推定し 2,000 超の場合は分割する。
+- **priority**: 9 / sprint: sprint-09
+
+### agent-crew-sprint-09-process-002
+- **lesson**: Sprint-08 retro で記録された高優先度 lesson（engineer-go 停止対策）のアクションが Sprint-09 のスプリント計画に反映されなかった。lesson を _lessons.json に記録しても、計画フ
+- **禁止行動**: Yuki（pm エージェント）がスプリント計画を立てる前に _lessons.json の priority_score >= 6 かつ未解決エントリを確認し、アクションを計画タスクに反映するステップを pm.md に追加する。
+- **priority**: 6 / sprint: sprint-09
+
+### agent-crew-sprint-10-process-001
+- **lesson**: delegate-impl の大半（queue.sh ディスパッチ委譲・complexityバリデーション・qa冪等性ガード）が Sprint-09 で完了済みだったことが実装着手後に発覚した。Yuki がスプリント計画時に前スプリントの実
+- **禁止行動**: pm.md の計画手順チェックリストに「前スプリントの DONE タスクの実装状態を確認し、計画済みだが未実装・実装済みだが未計画の両方を洗い出す」ステップを追加する。
+- **priority**: 4 / sprint: sprint-10
+
+### agent-crew-sprint-11-process-001
+- **lesson**: 
+- **禁止行動**: sora.md に「全タスク DONE 時は完了報告末尾に @retro を含める」を直接記載する。
+- **priority**: 8 / sprint: sprint-11
+
+### agent-crew-sprint-13-process-001
+- **lesson**: Antigravity が Issue #82（マルチプロダクト対応ロードマップ）の実装を Sprint-13 でスコープ外実装した。Issue #82 には「単体プロジェクト安定後に着手」と明記されていたにもかかわらず、session_s
+- **禁止行動**: エージェント定義（Antigravity または担当エージェント）に「Issue の着手条件（前提条件・制約）を実装開始前に必ず確認し、条件未成立の場合はスキップして Yuki に報告する」を追記する。Yuki のスプリント計画手順に「各 Issue の着手条件を _queue.json の notes に転記する」ステップを追加する。
+- **priority**: 6 / sprint: sprint-13
+
+### agent-crew-sprint-14-process-001
+- **lesson**: pm-learned-rules.md の初版作成時に、フィルタ条件 priority_score >= 3 のはずが priority:2 のエントリ（agent-crew-sprint-05-qa-001）が混入した。変換スクリプトや手
+- **禁止行動**: retro エージェント（みゆきち）が pm-learned-rules.md を更新する際は、追記前に jq で priority_score >= 3 を必ずフィルタし、変換後に全エントリの priority 値を確認するステップを手順に追加する。
+- **priority**: 4 / sprint: sprint-14


### PR DESCRIPTION
## Summary

- `scripts/propose-lesson-rules.sh` により `~/.claude/_lessons.json` から priority_score >= 4 の未対処 lesson を抽出
- 対象エージェント .md の「禁止パターン」セクションへ自動追記

## 変更ファイル

- `.claude/agents/engineer-go.md`
- `.claude/agents/pm.md`

## レビュー手順

1. 追記された禁止パターンの内容を確認する
2. 不要なエントリは削除してからマージする
3. マージ後、対応する lesson の status を `implemented` に更新する

## Test plan

- [x] 追記内容が既存セクションと重複していないこと（スクリプトが重複チェック済み）
- [ ] 追記されたルールが実際の lesson 内容と一致していること（目視確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)