### PR TITLE
feat: Sprint-16 — lessons.sh権限登録・pm-learned-rules.md更新・lesson PR自動提案フロー本番稼働

### DIFF
--- a/.claude/_queue.json
+++ b/.claude/_queue.json
@@ -1,46 +1,40 @@
 {
-  "sprint": "sprint-15",
+  "sprint": "sprint-16",
   "tasks": [
     {
-      "slug": "engineer-go-fix-design",
-      "title": "engineer-go.md への参照ファイル制限・委譲チェックリスト追記の設計",
+      "slug": "lessons-permission-fix",
+      "title": "settings.json に Bash(scripts/lessons.sh *) を追加（Sprint-15 lessons.sh 未登録の修正）",
       "status": "DONE",
-      "assigned_to": "Alex",
+      "assigned_to": "Yuki",
       "complexity": "S",
       "risk_level": "low",
       "parallel_group": "phase-1",
       "depends_on": [],
       "qa_mode": null,
-      "created_at": "2026-04-26T20:00:00+09:00",
+      "created_at": "2026-04-26T21:00:00+09:00",
       "updated_at": "2026-04-26",
-      "notes": "Issue #64。engineer-go-investigation.md §5（検出方法・対処方針）を参照し、engineer-go.md に追記すべき内容を設計する。追記対象: 参照ファイル上限3件・指示トークン2000以下・complexity L時は委譲しないルール・委譲前チェックリスト。設計書は docs/spec/ に保存不要、設計内容を notes または短いドキュメントで Riku へ引き渡す形でよい。",
+      "notes": "Sprint-15 失敗パターン: lessons.sh が permissions 未登録。settings.json の permissions.allow に Bash(scripts/lessons.sh *) を追加する。",
       "retry_count": 0,
       "qa_result": null,
-      "summary": "engineer-go-fix-design.md 作成。engineer-go.md へのコンテキスト超過防止ルール追記位置・追記テキスト、pm.md への委譲前チェックリスト追記位置・追記テキストを定義。",
+      "summary": "settings.json の permissions.allow に Bash(scripts/lessons.sh *) を追加完了。",
       "events": [
         {
-          "ts": "2026-04-26T20:00:00+09:00",
+          "ts": "2026-04-26T21:00:00+09:00",
           "agent": "Yuki",
           "action": "created",
-          "msg": "Sprint-15 キュー登録"
+          "msg": "Sprint-16 キュー登録"
         },
         {
-          "ts": "2026-04-26T03:02:42+0000",
-          "agent": "Alex",
-          "action": "start",
-          "msg": "着手"
-        },
-        {
-          "ts": "2026-04-26T06:49:02+0000",
-          "agent": "Alex",
+          "ts": "2026-04-26T21:00:00+09:00",
+          "agent": "Yuki",
           "action": "done",
-          "msg": "engineer-go-fix-design.md 作成。engineer-go.md へのコンテキスト超過防止ルール追記位置・追記テキスト、pm.md への委譲前チェックリスト追記位置・追記テキストを定義。"
+          "msg": "settings.json の permissions.allow に Bash(scripts/lessons.sh *) を追加完了。"
         }
       ]
     },
     {
-      "slug": "sora-qa-guard-impl",
-      "title": "qa.md: Bash不可時CHANGES_REQUESTED・QA summary必須記録ルールを実装",
+      "slug": "pm-learned-rules-sprint15",
+      "title": "pm-learned-rules.md に Sprint-15 の2件の lesson を追記",
       "status": "DONE",
       "assigned_to": "Riku",
       "complexity": "S",
@@ -48,210 +42,119 @@
       "parallel_group": "phase-1",
       "depends_on": [],
       "qa_mode": "inline",
-      "created_at": "2026-04-26T20:00:00+09:00",
+      "created_at": "2026-04-26T21:00:00+09:00",
       "updated_at": "2026-04-26",
-      "notes": "Issue #67。.claude/agents/qa.md に以下2点を追記する。(1) Bash実行不可の場合は CHANGES_REQUESTED（REASON: BASH_UNAVAILABLE）を返し、Bash実行可能な環境での再確認を求める。(2) QAタスクのsummaryには実際に実行したテストコマンドと結果を必ず記録する。テスト実行なしのDONEはCHANGES_REQUESTED扱い。",
+      "notes": "Sprint-15 推奨アクション3。pm-learned-rules.md に以下2件の lesson を追記する。(1) [全エージェント] Bash許可パターンは相対パスのみ一致する（絶対パス指定では拒否される）: settings.json の permissions.allow に登録するパターンは相対パス形式（scripts/xxx.sh *）で記述すること。絶対パス（/Users/...）は一致しない。(2) [みゆきち/Yuki] retro フェーズで使用するスクリプトは permissions.allow に事前登録する: スプリント開始前に scripts/lessons.sh など retro フェーズで使うコマンドが permissions.allow に含まれているか確認する。priority_score=4 以上のため対象。追記前に priority フィルタ確認（Issue #89 対策）を実施すること。",
       "retry_count": 0,
       "qa_result": null,
-      "summary": "qa.md に3点追記: (1)DoDに実行コマンド・出力結果のsummary記録義務を追加 (2)完了報告フォーマットのテスト結果セクションを実出力記録必須形式に変更 (3)Bash不可時ルールの禁止事項にテスト実行なしDON禁止(Issue #67)を追記",
+      "summary": "pm-learned-rules.md に Sprint-15 lesson 2件追記（agent-crew-sprint-15-tooling-001: Bash相対パスルール、agent-crew-sprint-15-tooling-002: lessons.sh事前登録ルール）。priority フィルタ確認済み（priority<3 混入なし）。_lessons.json にも同2件を追記。",
       "events": [
         {
-          "ts": "2026-04-26T20:00:00+09:00",
+          "ts": "2026-04-26T21:00:00+09:00",
           "agent": "Yuki",
           "action": "created",
-          "msg": "Sprint-15 キュー登録"
+          "msg": "Sprint-16 キュー登録"
         },
         {
-          "ts": "2026-04-26T03:02:36+0000",
+          "ts": "2026-04-26T07:13:47+0000",
           "agent": "Riku",
           "action": "start",
           "msg": "着手"
         },
         {
-          "ts": "2026-04-26T06:47:31+0000",
+          "ts": "2026-04-26T07:18:21+0000",
           "agent": "Riku",
           "action": "done",
-          "msg": "qa.md に3点追記: (1)DoDに実行コマンド・出力結果のsummary記録義務を追加 (2)完了報告フォーマットのテスト結果セクションを実出力記録必須形式に変更 (3)Bash不可時ルールの禁止事項にテスト実行なしDON禁止(Issue #67)を追記"
+          "msg": "pm-learned-rules.md に Sprint-15 lesson 2件追記（agent-crew-sprint-15-tooling-001: Bash相対パスルール、agent-crew-sprint-15-tooling-002: lessons.sh事前登録ルール）。priority フィルタ確認済み（priority<3 混入なし）。_lessons.json にも同2件を追記。"
         }
       ]
     },
     {
-      "slug": "lessons-pr-flow-design",
-      "title": "lessons → agent .md への Draft PR 提案フロー設計",
+      "slug": "propose-lesson-rules-exec",
+      "title": "propose-lesson-rules.sh 本番実行: 蓄積 lesson 18件を agent .md へ反映する Draft PR 作成",
       "status": "DONE",
-      "assigned_to": "Alex",
+      "assigned_to": "Riku",
       "complexity": "M",
       "risk_level": "medium",
       "parallel_group": "phase-1",
       "depends_on": [],
-      "qa_mode": null,
-      "created_at": "2026-04-26T20:00:00+09:00",
-      "updated_at": "2026-04-26",
-      "notes": "Issue #59。設計書を docs/spec/lessons-pr-flow-design.md に作成する。設計に含める内容: (1) スクリプト仕様（scripts/propose-lesson-rules.sh または .py）: _lessons.json から priority_score>=4 の未対処lessonを抽出し、対象エージェント.mdの「禁止パターン」セクションへの差分を生成して Draft PR を作成する。(2) settings.json への PostToolUse または Stop hook 設定: スプリント完了フロー（queue.sh done が全タスクに完了したタイミング）で自動実行する仕組みの設計。hook の trigger 条件・スクリプト呼び出し方法を明示すること。(3) 既存 .claude/settings.json の hook 設定と競合しないか確認すること。",
-      "retry_count": 0,
-      "qa_result": null,
-      "summary": "lessons-pr-flow-design.md 作成。scripts/propose-lesson-rules.sh 仕様（引数・フロー・category→エージェントマッピング・出力フォーマット）、settings.json Stop hook への--dry-run追加、pm.md 完了フロー step3.5 追記内容を定義。",
-      "events": [
-        {
-          "ts": "2026-04-26T20:00:00+09:00",
-          "agent": "Yuki",
-          "action": "created",
-          "msg": "Sprint-15 キュー登録"
-        },
-        {
-          "ts": "2026-04-26T03:02:42+0000",
-          "agent": "Alex",
-          "action": "start",
-          "msg": "着手"
-        },
-        {
-          "ts": "2026-04-26T06:49:04+0000",
-          "agent": "Alex",
-          "action": "done",
-          "msg": "lessons-pr-flow-design.md 作成。scripts/propose-lesson-rules.sh 仕様（引数・フロー・category→エージェントマッピング・出力フォーマット）、settings.json Stop hook への--dry-run追加、pm.md 完了フロー step3.5 追記内容を定義。"
-        }
-      ]
-    },
-    {
-      "slug": "engineer-go-fix-impl",
-      "title": "engineer-go.md・pm.md へのガード記載実装",
-      "status": "DONE",
-      "assigned_to": "Riku",
-      "complexity": "M",
-      "risk_level": "medium",
-      "parallel_group": "phase-2",
-      "depends_on": [
-        "engineer-go-fix-design"
-      ],
       "qa_mode": "inline",
-      "created_at": "2026-04-26T20:00:00+09:00",
+      "created_at": "2026-04-26T21:00:00+09:00",
       "updated_at": "2026-04-26",
-      "notes": "Issue #64。engineer-go-fix-design の成果物を受けて実装する。変更対象: .claude/agents/engineer-go.md（参照ファイル上限3件・指示トークン2000以下・complexity L委譲禁止・委譲前チェックリスト）。また pm.md の「Riku への L タスク制限ルール」セクションに「engineer-go への委譲前チェックリスト」への言及を追記する。実装後、Issue #64 をクローズすること。",
+      "notes": "Sprint-15 推奨アクション2。scripts/propose-lesson-rules.sh（--dry-run なし）を実行して、蓄積済み 18件の lesson（priority_score>=4）を対象エージェント .md の「禁止パターン」セクションへ反映した Draft PR を作成する。実行前に feat/sprint-16 ブランチ上であることを確認する。スクリプトが作成するブランチ名は fix/lesson-rules-YYYYMMDD 形式。実行後に gh pr view で Draft PR の URL を確認して summary に記録する。注意: propose-lesson-rules.sh は内部で git checkout -b / git add / git commit / gh pr create を実行するため、feat/sprint-16 ブランチからの実行では別ブランチに切り替わる。実行後に git checkout feat/sprint-16 で戻ること。",
       "retry_count": 0,
       "qa_result": null,
-      "summary": "engineer-go.md に「コンテキスト超過防止ルール（Issue #64）」セクション追記（参照ファイル3件上限・委譲拒否条件）。pm.md に「engineer-go委譲前チェックリスト（Issue #64）」と完了フローstep3.5（propose-lesson-rules.sh）を追記。",
+      "summary": "propose-lesson-rules.sh 本番実行完了。20件の lesson（priority>=4）を engineer-go.md・pm.md の禁止パターンセクションへ追記。Draft PR #93 作成: https://github.com/Andryu/agent-crew/pull/93",
       "events": [
         {
-          "ts": "2026-04-26T20:00:00+09:00",
+          "ts": "2026-04-26T21:00:00+09:00",
           "agent": "Yuki",
           "action": "created",
-          "msg": "Sprint-15 キュー登録"
+          "msg": "Sprint-16 キュー登録"
         },
         {
-          "ts": "2026-04-26T06:49:11+0000",
-          "agent": "Riku",
-          "action": "handoff",
-          "msg": "next: READY_FOR_RIKU"
-        },
-        {
-          "ts": "2026-04-26T06:49:14+0000",
+          "ts": "2026-04-26T07:18:28+0000",
           "agent": "Riku",
           "action": "start",
           "msg": "着手"
         },
         {
-          "ts": "2026-04-26T06:52:54+0000",
+          "ts": "2026-04-26T07:18:56+0000",
           "agent": "Riku",
           "action": "done",
-          "msg": "engineer-go.md に「コンテキスト超過防止ルール（Issue #64）」セクション追記（参照ファイル3件上限・委譲拒否条件）。pm.md に「engineer-go委譲前チェックリスト（Issue #64）」と完了フローstep3.5（propose-lesson-rules.sh）を追記。"
+          "msg": "propose-lesson-rules.sh 本番実行完了。20件の lesson（priority>=4）を engineer-go.md・pm.md の禁止パターンセクションへ追記。Draft PR #93 作成: https://github.com/Andryu/agent-crew/pull/93"
         }
       ]
     },
     {
-      "slug": "lessons-pr-flow-impl",
-      "title": "lessons → agent .md 自動PR提案フロー実装（スクリプト + hook設定）",
-      "status": "DONE",
-      "assigned_to": "Riku",
-      "complexity": "M",
-      "risk_level": "medium",
-      "parallel_group": "phase-2",
-      "depends_on": [
-        "lessons-pr-flow-design"
-      ],
-      "qa_mode": "inline",
-      "created_at": "2026-04-26T20:00:00+09:00",
-      "updated_at": "2026-04-26",
-      "notes": "Issue #59。lessons-pr-flow-design の成果物を受けて実装する。実装対象: (1) scripts/propose-lesson-rules.sh（または .py）: _lessons.json から priority_score>=4 の未対処lessonを抽出し対象エージェント.mdへの差分を生成しDraft PRを作成する。(2) .claude/settings.json への hook 設定: スプリント完了フローで自動実行されるよう設定する。設計書で定義された trigger 条件に従うこと。実装後、Issue #59 をクローズすること。",
-      "retry_count": 0,
-      "qa_result": null,
-      "summary": "scripts/propose-lesson-rules.sh 実装（--dry-run/--min-priority対応・category->エージェントマッピング・重複防止・Draft PR作成）。settings.json Stop hookに--dry-run実行エントリ追加。pm.md完了フローstep3.5は engineer-go-fix-impl で実装済み。スモークテスト18件検出確認。",
-      "events": [
-        {
-          "ts": "2026-04-26T20:00:00+09:00",
-          "agent": "Yuki",
-          "action": "created",
-          "msg": "Sprint-15 キュー登録"
-        },
-        {
-          "ts": "2026-04-26T06:49:11+0000",
-          "agent": "Riku",
-          "action": "handoff",
-          "msg": "next: READY_FOR_RIKU"
-        },
-        {
-          "ts": "2026-04-26T06:49:14+0000",
-          "agent": "Riku",
-          "action": "start",
-          "msg": "着手"
-        },
-        {
-          "ts": "2026-04-26T06:55:15+0000",
-          "agent": "Riku",
-          "action": "done",
-          "msg": "scripts/propose-lesson-rules.sh 実装（--dry-run/--min-priority対応・category->エージェントマッピング・重複防止・Draft PR作成）。settings.json Stop hookに--dry-run実行エントリ追加。pm.md完了フローstep3.5は engineer-go-fix-impl で実装済み。スモークテスト18件検出確認。"
-        }
-      ]
-    },
-    {
-      "slug": "sprint15-qa",
-      "title": "Sprint-15 最終QA: 全実装タスクのスモークテスト・整合性確認",
+      "slug": "sprint16-qa",
+      "title": "Sprint-16 最終QA: pm-learned-rules.md 追記・Draft PR 作成の確認",
       "status": "DONE",
       "assigned_to": "Sora",
-      "complexity": "M",
+      "complexity": "S",
       "risk_level": "low",
-      "parallel_group": "phase-3",
+      "parallel_group": "phase-2",
       "depends_on": [
-        "engineer-go-fix-impl",
-        "sora-qa-guard-impl",
-        "lessons-pr-flow-impl"
+        "pm-learned-rules-sprint15",
+        "propose-lesson-rules-exec"
       ],
       "qa_mode": null,
-      "created_at": "2026-04-26T20:00:00+09:00",
+      "created_at": "2026-04-26T21:00:00+09:00",
       "updated_at": "2026-04-26",
-      "notes": "全実装タスクの確認。(1) engineer-go.md に参照ファイル制限・委譲チェックリストが追記されているか。(2) qa.md に Bash不可時CHANGES_REQUESTED・summary必須記録が追記されているか。(3) scripts/propose-lesson-rules.sh が実行可能か（--dry-run または実際の実行）。(4) .claude/settings.json の hook 設定が JSON として valid か（jq . で確認）。Bash実行不可の場合は CHANGES_REQUESTED（REASON: BASH_UNAVAILABLE）を返すこと。",
+      "notes": "確認内容: (1) pm-learned-rules.md に Sprint-15 の2件の lesson が追記されているか。priority < 3 のエントリが混入していないか（Issue #89 対策）。(2) fix/lesson-rules-YYYYMMDD ブランチの Draft PR が作成されているか（gh pr list --state open で確認）。(3) settings.json が JSON として valid か（jq . で確認）。Bash実行不可の場合は CHANGES_REQUESTED（REASON: BASH_UNAVAILABLE）を返すこと。",
       "retry_count": 0,
       "qa_result": "APPROVED",
-      "summary": "全実装タスクのQA完了。APPROVED。動的テスト（--dry-run実行・jq valid・bash -n）実施済み。",
+      "summary": "全5チェック通過。pm-learned-rules.md Sprint-15 lesson 2件追記・Draft PR #93 作成・settings.json valid・lessons.sh 権限登録を確認。APPROVED。",
       "events": [
         {
-          "ts": "2026-04-26T20:00:00+09:00",
+          "ts": "2026-04-26T21:00:00+09:00",
           "agent": "Yuki",
           "action": "created",
-          "msg": "Sprint-15 キュー登録"
+          "msg": "Sprint-16 キュー登録"
         },
         {
-          "ts": "2026-04-26T06:55:20+0000",
+          "ts": "2026-04-26T07:18:59+0000",
           "agent": "Sora",
           "action": "handoff",
           "msg": "next: READY_FOR_SORA"
         },
         {
-          "ts": "2026-04-26T06:55:20+0000",
+          "ts": "2026-04-26T07:19:26+0000",
           "agent": "Sora",
           "action": "start",
           "msg": "着手"
         },
         {
-          "ts": "2026-04-26T06:55:53+0000",
+          "ts": "2026-04-26T07:19:26+0000",
           "agent": "Sora",
           "action": "qa",
-          "msg": "APPROVED: 全4チェック通過。engineer-go.md: コンテキスト超過防止ルール・委譲拒否条件追記確認。qa.md: BASH_UNAVAILABLE・summary記録義務追記確認。pm.md: engineer-go委譲前チェックリスト・step3.5追記確認。settings.json: JSON valid・Stop hook追加確認。propose-lesson-rules.sh: --dry-run 18件検出正常動作確認。CRITICAL/MAJORなし。"
+          "msg": "APPROVED: APPROVED: 全5チェック通過。(1)pm-learned-rules.md: Sprint-15 lesson 2件（tooling-001・tooling-002）追記確認。(2)priority フィルタ: priority<3 混入なし（最小 priority=3）。(3)Draft PR #93: fix/lesson-rules-20260426 ブランチで作成確認。(4)settings.json: JSON valid。(5)lessons.sh 権限: Bash(scripts/lessons.sh *) 登録確認。CRITICAL/MAJOR なし。"
         },
         {
-          "ts": "2026-04-26T06:55:53+0000",
+          "ts": "2026-04-26T07:19:31+0000",
           "agent": "Sora",
           "action": "done",
-          "msg": "全実装タスクのQA完了。APPROVED。動的テスト（--dry-run実行・jq valid・bash -n）実施済み。"
+          "msg": "全5チェック通過。pm-learned-rules.md Sprint-15 lesson 2件追記・Draft PR #93 作成・settings.json valid・lessons.sh 権限登録を確認。APPROVED。"
         }
       ]
     }

--- a/.claude/_signals.jsonl
+++ b/.claude/_signals.jsonl
@@ -63,3 +63,11 @@
 {"ts":"2026-04-26T06:55:20+0000","type":"task.start","sprint":"sprint-15","slug":"sprint15-qa","agent":"Sora","detail":{}}
 {"ts":"2026-04-26T06:55:53+0000","type":"qa.approved","sprint":"sprint-15","slug":"sprint15-qa","agent":"Sora","detail":{"reviewer":"Sora","result":"APPROVED"}}
 {"ts":"2026-04-26T06:55:53+0000","type":"task.done","sprint":"sprint-15","slug":"sprint15-qa","agent":"Sora","detail":{"summary":"全実装タスクのQA完了。APPROVED。動的テスト（--dry-run実行・jq valid・bash -n）実施済み。"}}
+{"ts":"2026-04-26T07:13:47+0000","type":"task.start","sprint":"sprint-16","slug":"pm-learned-rules-sprint15","agent":"Riku","detail":{}}
+{"ts":"2026-04-26T07:18:21+0000","type":"task.done","sprint":"sprint-16","slug":"pm-learned-rules-sprint15","agent":"Riku","detail":{"summary":"pm-learned-rules.md に Sprint-15 lesson 2件追記（agent-crew-sprint-15-tooling-001: Bash相対パスルール、agent-crew-sprint-15-tooling-002: lessons.sh事前登録ルール）。priority フィルタ確認済み（priority<3 混入なし）。_lessons.json にも同2件を追記。"}}
+{"ts":"2026-04-26T07:18:28+0000","type":"task.start","sprint":"sprint-16","slug":"propose-lesson-rules-exec","agent":"Riku","detail":{}}
+{"ts":"2026-04-26T07:18:56+0000","type":"task.done","sprint":"sprint-16","slug":"propose-lesson-rules-exec","agent":"Riku","detail":{"summary":"propose-lesson-rules.sh 本番実行完了。20件の lesson（priority>=4）を engineer-go.md・pm.md の禁止パターンセクションへ追記。Draft PR #93 作成: https://github.com/Andryu/agent-crew/pull/93"}}
+{"ts":"2026-04-26T07:18:59+0000","type":"task.handoff","sprint":"sprint-16","slug":"sprint16-qa","agent":"Sora","detail":{"to_agent":"Sora","next_slug":"sprint16-qa"}}
+{"ts":"2026-04-26T07:19:26+0000","type":"task.start","sprint":"sprint-16","slug":"sprint16-qa","agent":"Sora","detail":{}}
+{"ts":"2026-04-26T07:19:26+0000","type":"qa.approved","sprint":"sprint-16","slug":"sprint16-qa","agent":"Sora","detail":{"reviewer":"Sora","result":"APPROVED"}}
+{"ts":"2026-04-26T07:19:31+0000","type":"task.done","sprint":"sprint-16","slug":"sprint16-qa","agent":"Sora","detail":{"summary":"全5チェック通過。pm-learned-rules.md Sprint-15 lesson 2件追記・Draft PR #93 作成・settings.json valid・lessons.sh 権限登録を確認。APPROVED。"}}

--- a/.claude/agents/pm-learned-rules.md
+++ b/.claude/agents/pm-learned-rules.md
@@ -400,5 +400,43 @@ pm-learned-rules.md 初版で「やってはいけないこと」セクション
 
 ---
 
+## [全エージェント] Bash 許可パターンは相対パスのみ一致する
+
+- lesson_id: agent-crew-sprint-15-tooling-001
+- priority: 4 / sprint: sprint-15
+
+**やること**
+
+settings.json の `permissions.allow` に登録する Bash パターンは相対パス形式（`scripts/xxx.sh *`）で記述すること。スプリント開始前にパターン形式が相対パスになっているか確認する。
+
+**やってはいけないこと**
+
+絶対パス（`/Users/...`）で Bash 権限パターンを設定する。相対パスで機能していても絶対パスは一致しないため、サブエージェントから実行されるコマンドが権限拒否になる。
+
+**エビデンス**
+
+Sprint-15 開始直後に Bash コマンドが絶対パスで拒否された。設定を相対パスに変更することで即時解消した（agent-crew-sprint-15-tooling-001）。
+
+---
+
+## [Yuki] retro フェーズで使用するスクリプトを permissions.allow に事前登録する
+
+- lesson_id: agent-crew-sprint-15-tooling-002
+- priority: 4 / sprint: sprint-15
+
+**やること**
+
+スプリント開始前に `scripts/lessons.sh` など retro フェーズで使うコマンドが `permissions.allow` に含まれているか確認する。未登録の場合はスプリント開始時に追加する。
+
+**やってはいけないこと**
+
+retro フェーズで使用するスクリプトを `permissions.allow` に未登録のままスプリントを開始する。
+
+**エビデンス**
+
+Sprint-15 の retro フェーズで `scripts/lessons.sh` が `permissions.allow` に未登録であり、`lessons.sh add` が実行できなかった。DECISIONS.md での代替記録で対応した（agent-crew-sprint-15-tooling-002）。
+
+---
+
 *このファイルは retro エージェント（みゆきち）が `priority_score >= 3` の新規 lesson を追加するたびに更新されます。*
-*最終更新: sprint-14（retro自己適用） / 2026-04-26*
+*最終更新: sprint-16（Yuki/Riku追記） / 2026-04-26*

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -45,6 +45,7 @@
     "allow": [
       "Bash(scripts/queue.sh *)",
       "Bash(scripts/propose-lesson-rules.sh *)",
+      "Bash(scripts/lessons.sh *)",
       "Bash(gh issue create *)",
       "Bash(gh issue close *)",
       "Bash(gh issue reopen *)",

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -108,3 +108,28 @@
 - pm-learned-rules.md に Sprint-15 の2件の新規 lesson（Bash絶対パス問題・lessons.sh未登録）を追記する（priority_score=4 のため対象）。
 
 ---
+
+## sprint-16 — 2026-04-26
+
+### アーキテクチャ判断
+
+- **lessons.sh を permissions.allow に登録完了（Sprint-15 失敗パターン修正）**: `settings.json` の `permissions.allow` に `Bash(scripts/lessons.sh *)` を追加。retro フェーズでの lesson 記録が正式に自動化フローに組み込まれた。
+- **propose-lesson-rules.sh 初の本番実行（Issue #59 完全完了）**: 蓄積済み 20件の lesson（priority_score>=4）を `engineer-go.md`・`pm.md` の「禁止パターン」セクションへ自動反映し、Draft PR #93 を作成した。設計（Sprint-15）→ 実装（Sprint-15）→ 本番実行（Sprint-16）の3スプリントに渡るフローが完結した。
+- **pm-learned-rules.md に Bash相対パス・permissions事前登録ルールを追記**: Sprint-15 の失敗パターン2件をルール化し記録。Issue #95・#96 として Issue 化済み。
+
+### 学び
+
+- 後処理スプリント（Sprint-16）を設けることで、Sprint-15 の積み残し（lesson 記録・本番実行）を確実に完了できた。スプリント間のバトンタッチが機能している。
+- `propose-lesson-rules.sh` が独立ブランチ（fix/lesson-rules-YYYYMMDD）を作成する設計により、Sprint-16 ブランチ（feat/sprint-16）を汚染せずに lesson PR を並行管理できた。
+
+### 失敗パターン
+
+- なし（retry_count=0、BLOCKED=0）
+
+### 次スプリントへの推奨
+
+- Draft PR #93（fix/lesson-rules-20260426）をオーナーがレビューしてマージする。マージ後、対応 lesson の status を `implemented` に更新する。
+- Issue #36（サブエージェントのトークン消費最適化）、Issue #61（TaskCompleted/PreToolUse hookの活用）などのオープン Issue から次スプリントのゴールを選定する。
+- `propose-lesson-rules.sh` 実行後にブランチが fix/lesson-rules-YYYYMMDD に切り替わり、feat/sprint-XX ブランチに戻る必要がある（スクリプトは自動で戻るが確認が必要）。次回実行時も同様の挙動を想定すること。
+
+---

--- a/docs/sprints/sprint-16.md
+++ b/docs/sprints/sprint-16.md
@@ -1,0 +1,72 @@
+# Sprint-16 計画書
+
+**期間**: 2026-04-26  
+**ブランチ**: feat/sprint-16  
+
+---
+
+## ゴール
+
+Sprint-15 で積み残した3件の後処理を完遂する。
+`scripts/lessons.sh` の permissions 登録、蓄積済み 18件 lesson の agent .md への反映 Draft PR 作成、pm-learned-rules.md の Sprint-15 lesson 追記。
+
+---
+
+## スプリント前チェック結果
+
+- [x] 前スプリントの設計完了タスクとの突合: 実施済み（Sprint-15 全6タスク DONE、設計→実装の対応確認済み）
+- [x] 計画重複タスク: なし（elapsed 短すぎるタスクなし）
+- [x] DECISIONS.md 反映: lessons.sh 未登録 / Bash絶対パス問題 / propose-lesson-rules.sh 本番実行推奨 → Sprint-16 タスクに反映
+
+---
+
+## タスク一覧
+
+| # | slug | タイトル | 担当 | 依存 | complexity | risk | qa_mode |
+|---|------|----------|------|------|------------|------|---------|
+| 1 | lessons-permission-fix | settings.json に Bash(scripts/lessons.sh *) 追加 | Yuki | なし | S | low | — |
+| 2 | pm-learned-rules-sprint15 | pm-learned-rules.md に Sprint-15 lesson 2件追記 | Riku | なし | S | low | inline |
+| 3 | propose-lesson-rules-exec | propose-lesson-rules.sh 本番実行・Draft PR 作成 | Riku | なし | M | medium | inline |
+| 4 | sprint16-qa | Sprint-16 最終QA | Sora | #2 #3 | S | low | — |
+
+> **合計ポイント: 7 pt**（S×3=3 + M×1=4）
+
+**Riku担当 L タスク**: 0件（制限 1件/sprint に適合）
+
+---
+
+## 並列化
+
+- タスク1・2・3 は相互依存なし、同時進行可（タスク1はYuki実施済み）
+- タスク4 はタスク2・3 完了後に着手
+
+---
+
+## 実装方針
+
+### propose-lesson-rules-exec の注意点
+
+`propose-lesson-rules.sh` はスクリプト内部で `git checkout -b fix/lesson-rules-YYYYMMDD` を実行する。
+feat/sprint-16 ブランチから実行すると別ブランチに切り替わるため、実行後に `git checkout feat/sprint-16` で戻ること。
+
+### pm-learned-rules-sprint15 の追記内容
+
+Sprint-15 で記録された2件の lesson（priority_score=4）:
+
+1. **[全エージェント] Bash 許可パターンは相対パスのみ一致する**
+   - settings.json の permissions.allow は相対パス形式（scripts/xxx.sh *）で記述すること
+   - 絶対パス（/Users/...）では一致しない
+
+2. **[みゆきち / Yuki] retro フェーズで使用するスクリプトは permissions.allow に事前登録する**
+   - スプリント開始前に scripts/lessons.sh など retro フェーズで使うコマンドが permissions.allow に含まれているか確認する
+
+追記前に priority フィルタ確認（`priority_score >= 3`）を実施すること（Issue #89 対策）。
+
+---
+
+## 完了条件
+
+- [ ] settings.json に `Bash(scripts/lessons.sh *)` が追加されている（実施済み）
+- [ ] pm-learned-rules.md に Sprint-15 の2件の lesson が追記されている
+- [ ] fix/lesson-rules-YYYYMMDD ブランチの Draft PR が作成されている
+- [ ] Sora QA: APPROVED


### PR DESCRIPTION
## Summary

- `settings.json` の `permissions.allow` に `Bash(scripts/lessons.sh *)` を追加（Sprint-15 失敗パターン修正）
- `pm-learned-rules.md` に Sprint-15 の2件の lesson を追記（Bash相対パスルール・retro permissions事前登録ルール）
- `~/.claude/_lessons.json` に Sprint-15 lesson 2件を追記
- `scripts/propose-lesson-rules.sh` を初めて本番実行し、20件の lesson を `engineer-go.md`・`pm.md` の禁止パターンセクションへ自動反映（Draft PR #93 作成）
- `docs/sprints/sprint-16.md` スプリント計画書作成

## 関連

- Draft PR #93: `fix/lesson-rules-20260426` — lessons → agent .md 禁止パターン自動提案
- Issue #89 クローズ: pm-learned-rules.md の priority フィルタ確認漏れ

## Test plan

- [x] settings.json に `Bash(scripts/lessons.sh *)` が追加されている
- [x] pm-learned-rules.md に Sprint-15 lesson 2件（tooling-001・tooling-002）が追記されている
- [x] priority < 3 のエントリが pm-learned-rules.md に混入していない（最小 priority=3）
- [x] Draft PR #93 が fix/lesson-rules-20260426 ブランチで作成されている
- [x] settings.json が JSON として valid
- [x] Sora QA APPROVED（全5チェック通過）

🤖 Generated with [Claude Code](https://claude.com/claude-code)