### PR TITLE
feat: Sprint-18 — Issue重複整理・lesson status更新・hook動作確認

### DIFF
--- a/.claude/_queue.json
+++ b/.claude/_queue.json
@@ -1,46 +1,9 @@
 {
-  "sprint": "sprint-17",
+  "sprint": "sprint-18",
   "tasks": [
     {
-      "slug": "hook-design",
-      "title": "TaskCompleted hook の設計（settings.json 組み込み設計・SubagentStop 責務再定義含む）",
-      "status": "DONE",
-      "assigned_to": "Alex",
-      "complexity": "M",
-      "risk_level": "medium",
-      "parallel_group": "phase-1",
-      "depends_on": [],
-      "qa_mode": null,
-      "created_at": "2026-04-26T22:00:00+09:00",
-      "updated_at": "2026-04-26",
-      "notes": "Issue #61 対応。設計書 docs/spec/hook-taskcompleted-design.md を作成する。内容: (1) TaskCompleted hook の責務定義（シグナル emit・queue ステータス更新など）、(2) settings.json への組み込み方法、(3) SubagentStop hook との責務分離・再定義、(4) Bash コードサンプルは bash -n でバリデーション済みのものを含めること（pm-learned-rules.md [Alex] ルール準拠）。着手条件: なし。",
-      "retry_count": 0,
-      "qa_result": null,
-      "summary": "設計書 docs/spec/hook-taskcompleted-design.md を作成。TaskCompleted hook の責務定義・settings.json 組み込み方法・SubagentStop との責務分離・Bash サンプルコードを記述。",
-      "events": [
-        {
-          "ts": "2026-04-26T22:00:00+09:00",
-          "agent": "Yuki",
-          "action": "created",
-          "msg": "Sprint-17 キュー登録"
-        },
-        {
-          "ts": "2026-04-26T13:53:41+0000",
-          "agent": "Alex",
-          "action": "start",
-          "msg": "着手"
-        },
-        {
-          "ts": "2026-04-26T13:54:35+0000",
-          "agent": "Alex",
-          "action": "done",
-          "msg": "設計書 docs/spec/hook-taskcompleted-design.md を作成。TaskCompleted hook の責務定義・settings.json 組み込み方法・SubagentStop との責務分離・Bash サンプルコードを記述。"
-        }
-      ]
-    },
-    {
-      "slug": "lesson-issue-close",
-      "title": "PR #93 マージ済み対応: lesson status 更新 + Issue #95 #96 #78 #36 クローズ",
+      "slug": "lesson-dedup-close",
+      "title": "Issue #99/#100 重複クローズ + sprint-17-tooling-001 lesson status 更新",
       "status": "DONE",
       "assigned_to": "Yuki",
       "complexity": "S",
@@ -48,164 +11,147 @@
       "parallel_group": "phase-1",
       "depends_on": [],
       "qa_mode": null,
-      "created_at": "2026-04-26T22:00:00+09:00",
-      "updated_at": "2026-04-26T22:00:00+09:00",
-      "notes": "着手条件: PR #93 が MERGED 済みであること（確認済み）。実施内容: (1) ~/.claude/_lessons.json の PR #93 で反映済み lesson の status を implemented に更新、(2) Issue #95・#96・#78 をクローズ（pm-learned-rules.md 反映済みのため）、(3) Issue #36 をクローズ（ADR 既存・pm.md/engineer-go.md 反映済みのため）。",
+      "created_at": "2026-04-26T23:00:00+09:00",
+      "updated_at": "2026-04-26T23:10:00+09:00",
+      "notes": "Issue #99 と #100 は同じ lesson（agent-crew-sprint-17-tooling-001）から二重生成された重複 Issue。#99 をクローズし #100 を残す（#100 の方が新しく内容が正確）。その後 ~/.claude/_lessons.json の agent-crew-sprint-17-tooling-001 の status を implemented に更新する（settings.json への権限追加は Sprint-17 で完了済みのため）。着手条件: なし。",
       "retry_count": 0,
       "qa_result": null,
-      "summary": "Issue #95/#96/#78/#36 クローズ完了。_lessons.json の10件（sprint-15-tooling-001/002・sprint-11-reliability-001/002・sprint-11-process-001・sprint-08-tooling-001/reliability-001・sprint-09-process-001/002・sprint-12-reliability-001）の status を implemented に更新。",
+      "summary": "Issue #99 をクローズ（#100 に統合）。~/.claude/_lessons.json の agent-crew-sprint-17-tooling-001 の status を implemented に更新。",
       "events": [
         {
-          "ts": "2026-04-26T22:00:00+09:00",
+          "ts": "2026-04-26T23:00:00+09:00",
           "agent": "Yuki",
           "action": "created",
-          "msg": "Sprint-17 キュー登録"
+          "msg": "Sprint-18 キュー登録"
         },
         {
-          "ts": "2026-04-26T22:00:00+09:00",
+          "ts": "2026-04-26T23:05:00+09:00",
           "agent": "Yuki",
           "action": "start",
           "msg": "着手"
         },
         {
-          "ts": "2026-04-26T22:05:00+09:00",
+          "ts": "2026-04-26T23:10:00+09:00",
           "agent": "Yuki",
           "action": "done",
-          "msg": "Issue #95/#96/#78/#36 クローズ。_lessons.json 10件 status=implemented 更新完了。"
+          "msg": "Issue #99 CLOSED（#100 に統合）。_lessons.json agent-crew-sprint-17-tooling-001 status=implemented 更新完了。"
         }
       ]
     },
     {
-      "slug": "agent-precondition-doc",
-      "title": "Issue #86 対応 — engineer-go.md に「着手条件チェック」ルールを追記",
-      "status": "DONE",
-      "assigned_to": "Riku",
-      "complexity": "S",
-      "risk_level": "low",
-      "parallel_group": "phase-1",
-      "depends_on": [],
-      "qa_mode": "inline",
-      "created_at": "2026-04-26T22:00:00+09:00",
-      "updated_at": "2026-04-26",
-      "notes": "Issue #86 対応。着手条件: Issue #86 がオープンであること（確認済み）。対象ファイル: .claude/agents/engineer-go.md（1件のみ）。追記内容: 「タスク着手前に _queue.json の notes フィールドで着手条件を確認する。着手条件が未成立の場合は実装を開始せず Yuki へ報告する。」を禁止パターンまたはタスク開始手順セクションに追記する。変更ファイル: .claude/agents/engineer-go.md のみ（1件）。完了後に Yuki へ inline QA 報告すること。",
-      "retry_count": 0,
-      "qa_result": null,
-      "summary": "engineer-go.md の委譲拒否条件と着手時フローに着手条件チェックを追記（Issue #86 対応）。変更ファイル: .claude/agents/engineer-go.md のみ。",
-      "events": [
-        {
-          "ts": "2026-04-26T22:00:00+09:00",
-          "agent": "Yuki",
-          "action": "created",
-          "msg": "Sprint-17 キュー登録"
-        },
-        {
-          "ts": "2026-04-26T08:12:34+0000",
-          "agent": "Riku",
-          "action": "start",
-          "msg": "着手"
-        },
-        {
-          "ts": "2026-04-26T08:15:07+0000",
-          "agent": "Riku",
-          "action": "done",
-          "msg": "engineer-go.md の委譲拒否条件と着手時フローに着手条件チェックを追記（Issue #86 対応）。変更ファイル: .claude/agents/engineer-go.md のみ。"
-        }
-      ]
-    },
-    {
-      "slug": "hook-impl",
-      "title": "TaskCompleted hook 実装（.claude/hooks/task_completed.sh 新規作成 + settings.json 更新）",
-      "status": "DONE",
-      "assigned_to": "Riku",
-      "complexity": "M",
-      "risk_level": "medium",
-      "parallel_group": "phase-2",
-      "depends_on": [
-        "hook-design"
-      ],
-      "qa_mode": "inline",
-      "created_at": "2026-04-26T22:00:00+09:00",
-      "updated_at": "2026-04-26",
-      "notes": "着手条件: hook-design タスクが DONE で docs/spec/hook-taskcompleted-design.md が存在すること。実装内容は設計書に従う。変更ファイル上限3件（.claude/hooks/task_completed.sh, .claude/settings.json, 必要に応じて .claude/hooks/subagent_stop.sh）。指示文は 2,000 トークン以下で作成する（engineer-go 委譲前チェックリスト準拠）。qa_mode: inline（実装後に Sora QA 前に自己確認）。",
-      "retry_count": 0,
-      "qa_result": null,
-      "summary": ".claude/hooks/task_completed.sh 新規作成（bash -n 構文OK・chmod +x済み）。settings.json に TaskCompleted hook を登録。jq valid 確認済み。変更ファイル: task_completed.sh, settings.json の2件。",
-      "events": [
-        {
-          "ts": "2026-04-26T22:00:00+09:00",
-          "agent": "Yuki",
-          "action": "created",
-          "msg": "Sprint-17 キュー登録"
-        },
-        {
-          "ts": "2026-04-26T13:54:43+0000",
-          "agent": "Riku",
-          "action": "handoff",
-          "msg": "next: READY_FOR_RIKU"
-        },
-        {
-          "ts": "2026-04-26T13:54:46+0000",
-          "agent": "Riku",
-          "action": "start",
-          "msg": "着手"
-        },
-        {
-          "ts": "2026-04-26T13:56:41+0000",
-          "agent": "Riku",
-          "action": "done",
-          "msg": ".claude/hooks/task_completed.sh 新規作成（bash -n 構文OK・chmod +x済み）。settings.json に TaskCompleted hook を登録。jq valid 確認済み。変更ファイル: task_completed.sh, settings.json の2件。"
-        }
-      ]
-    },
-    {
-      "slug": "sprint17-qa",
-      "title": "Sprint-17 最終QA: hook実装・エージェント定義追記の確認",
+      "slug": "hook-smoke-test",
+      "title": "TaskCompleted hook 実動作確認（スモークテスト）",
       "status": "DONE",
       "assigned_to": "Sora",
       "complexity": "S",
       "risk_level": "low",
-      "parallel_group": "phase-3",
-      "depends_on": [
-        "agent-precondition-doc",
-        "hook-impl"
-      ],
+      "parallel_group": "phase-1",
+      "depends_on": [],
       "qa_mode": null,
-      "created_at": "2026-04-26T22:00:00+09:00",
-      "updated_at": "2026-04-26",
-      "notes": "確認内容: (1) .claude/hooks/task_completed.sh が存在し bash -n で構文エラーなしか。(2) settings.json に TaskCompleted hook が正しく登録されているか（jq . で確認）。(3) .claude/agents/engineer-go.md に着手条件チェックルールが追記されているか。(4) Bash 実行不可の場合は CHANGES_REQUESTED（REASON: BASH_UNAVAILABLE）を返すこと。",
+      "created_at": "2026-04-26T23:00:00+09:00",
+      "updated_at": "2026-04-26T23:10:00+09:00",
+      "notes": "Sprint-17 で導入した TaskCompleted hook の実動作を確認する。確認内容: (1) .claude/hooks/task_completed.sh が存在し実行権限があるか（ls -la）。(2) .claude/_signals.jsonl に sprint-17 の task_completed イベントが記録されているか（jq で確認）。(3) task_completed イベントのレコードが正しい JSON 形式か（ts/sprint/slug/agent/event フィールドが存在するか）。(4) settings.json の TaskCompleted hook 設定が正しいか（jq . で確認）。結果を summary に記録して DONE にする。Bash 不可の場合は CHANGES_REQUESTED（REASON: BASH_UNAVAILABLE）を返すこと。着手条件: なし。",
       "retry_count": 0,
       "qa_result": "APPROVED",
-      "summary": "全5チェック APPROVED。task_completed.sh・settings.json・engineer-go.md の変更を確認。",
+      "summary": "(1) task_completed.sh 存在・-rwxr-xr-x・bash -n OK。(2) _signals.jsonl に sprint-17 task_completed イベント存在（ts=2026-04-26T13:57:09+0000 slug=sprint17-qa）。(3) JSON フィールド ts/sprint/slug/agent/event 全て有効。(4) settings.json に TaskCompleted hook 登録確認。全4チェック PASS。",
       "events": [
         {
-          "ts": "2026-04-26T22:00:00+09:00",
+          "ts": "2026-04-26T23:00:00+09:00",
           "agent": "Yuki",
           "action": "created",
-          "msg": "Sprint-17 キュー登録"
+          "msg": "Sprint-18 キュー登録"
         },
         {
-          "ts": "2026-04-26T13:56:41+0000",
-          "agent": "Sora",
-          "action": "handoff",
-          "msg": "next: READY_FOR_SORA"
-        },
-        {
-          "ts": "2026-04-26T13:56:44+0000",
+          "ts": "2026-04-26T23:05:00+09:00",
           "agent": "Sora",
           "action": "start",
           "msg": "着手"
         },
         {
-          "ts": "2026-04-26T13:57:22+0000",
-          "agent": "Sora",
-          "action": "qa",
-          "msg": "APPROVED: 全5チェック通過。(1)task_completed.sh 存在・bash -n OK・chmod +x済み。(2)settings.json に TaskCompleted hook 登録確認。(3)settings.json jq valid。(4)engineer-go.md に着手条件チェック2箇所追記確認（行114:委譲拒否条件、行119:着手時フロー）。(5)スモークテスト: _signals.jsonl に task_completed イベント emit・JSON valid確認。CRITICAL/MAJOR なし。"
-        },
-        {
-          "ts": "2026-04-26T13:57:22+0000",
+          "ts": "2026-04-26T23:10:00+09:00",
           "agent": "Sora",
           "action": "done",
-          "msg": "全5チェック APPROVED。task_completed.sh・settings.json・engineer-go.md の変更を確認。"
+          "msg": "全4チェック PASS。task_completed.sh 実行権限あり・bash -n OK・_signals.jsonl に task_completed イベント存在・JSON フィールド有効・settings.json 登録確認。"
+        }
+      ]
+    },
+    {
+      "slug": "pm-rules-update",
+      "title": "pm-learned-rules.md の未コミット変更をコミット + 最終更新日を sprint-18 に更新",
+      "status": "DONE",
+      "assigned_to": "Yuki",
+      "complexity": "S",
+      "risk_level": "low",
+      "parallel_group": "phase-1",
+      "depends_on": [],
+      "qa_mode": null,
+      "created_at": "2026-04-26T23:00:00+09:00",
+      "updated_at": "2026-04-26T23:10:00+09:00",
+      "notes": "pm-learned-rules.md に sprint-17 の2件の lesson（sprint-17-tooling-001・sprint-17-reliability-001）が未コミットで残っている。最終更新日を sprint-18 / 2026-04-26 に更新してからコミットに含める。変更ファイル: .claude/agents/pm-learned-rules.md のみ。着手条件: なし。",
+      "retry_count": 0,
+      "qa_result": null,
+      "summary": "pm-learned-rules.md の最終更新日を sprint-18 / 2026-04-26 に更新。sprint-17 の2件の lesson エントリを含む未コミット変更を確認。",
+      "events": [
+        {
+          "ts": "2026-04-26T23:00:00+09:00",
+          "agent": "Yuki",
+          "action": "created",
+          "msg": "Sprint-18 キュー登録"
+        },
+        {
+          "ts": "2026-04-26T23:05:00+09:00",
+          "agent": "Yuki",
+          "action": "start",
+          "msg": "着手"
+        },
+        {
+          "ts": "2026-04-26T23:10:00+09:00",
+          "agent": "Yuki",
+          "action": "done",
+          "msg": "pm-learned-rules.md 最終更新日を sprint-18 に更新。2件のsprint-17 lesson エントリ（sprint-17-tooling-001・sprint-17-reliability-001）を含む変更確定。"
+        }
+      ]
+    },
+    {
+      "slug": "sprint18-qa",
+      "title": "Sprint-18 最終QA",
+      "status": "DONE",
+      "assigned_to": "Sora",
+      "complexity": "S",
+      "risk_level": "low",
+      "parallel_group": "phase-2",
+      "depends_on": ["lesson-dedup-close", "hook-smoke-test", "pm-rules-update"],
+      "qa_mode": null,
+      "created_at": "2026-04-26T23:00:00+09:00",
+      "updated_at": "2026-04-26T23:15:00+09:00",
+      "notes": "確認内容: (1) Issue #99 が CLOSED か（gh issue view 99）。(2) ~/.claude/_lessons.json の agent-crew-sprint-17-tooling-001 の status が implemented か（jq）。(3) .claude/_signals.jsonl に task_completed イベントが存在するか。(4) pm-learned-rules.md の最終更新日が sprint-18 になっているか。(5) _queue.json の sprint が sprint-18 になっているか。全て PASS なら APPROVED、1件でも NG なら CHANGES_REQUESTED。",
+      "retry_count": 0,
+      "qa_result": "APPROVED",
+      "summary": "全5チェック APPROVED。(1)Issue #99 CLOSED確認。(2)_lessons.json sprint-17-tooling-001 status=implemented確認。(3)_signals.jsonl task_completed イベント存在確認。(4)pm-learned-rules.md 最終更新日 sprint-18 確認。(5)_queue.json sprint=sprint-18 確認。CRITICAL/MAJOR なし。",
+      "events": [
+        {
+          "ts": "2026-04-26T23:00:00+09:00",
+          "agent": "Yuki",
+          "action": "created",
+          "msg": "Sprint-18 キュー登録"
+        },
+        {
+          "ts": "2026-04-26T23:12:00+09:00",
+          "agent": "Sora",
+          "action": "start",
+          "msg": "着手"
+        },
+        {
+          "ts": "2026-04-26T23:15:00+09:00",
+          "agent": "Sora",
+          "action": "qa",
+          "msg": "APPROVED: 全5チェック通過。(1)#99 CLOSED。(2)sprint-17-tooling-001 status=implemented。(3)_signals.jsonl task_completed イベント存在。(4)pm-learned-rules.md sprint-18 更新済み。(5)_queue.json sprint=sprint-18。"
+        },
+        {
+          "ts": "2026-04-26T23:15:00+09:00",
+          "agent": "Sora",
+          "action": "done",
+          "msg": "全5チェック APPROVED。CRITICAL/MAJOR なし。@retro を起動してください。"
         }
       ]
     }

--- a/.claude/agents/pm-learned-rules.md
+++ b/.claude/agents/pm-learned-rules.md
@@ -438,5 +438,39 @@ Sprint-15 の retro フェーズで `scripts/lessons.sh` が `permissions.allow`
 
 ---
 
+## [Yuki] フック実装タスクに必要な権限を計画時に settings.json へ事前登録する
+
+- lesson_id: agent-crew-sprint-17-tooling-001
+- priority: 6 / sprint: sprint-17
+
+**やること**
+
+フック実装タスクをキューに積む際、`notes` に必要権限（`Write(**)`・`Bash(chmod *)`・`Bash(bash *)`）を明記し、スプリント開始前に `settings.json` の `permissions.allow` に追加しておく。
+
+**やってはいけないこと**
+
+フック実装タスクを計画する際に権限要件を洗い出さず、実行時に権限拒否で手動追記対処する。
+
+**エビデンス**
+
+Sprint-17 で `Write(**)`・`Bash(chmod *)`・`Bash(bash *)` が `settings.json` に未登録だったため、Yuki が hook-impl タスク中に2回権限拒否ブロックに遭遇した。settings.json への手動追記で対処した（agent-crew-sprint-17-tooling-001、Issue #100）。
+
+---
+
+## [全エージェント] _queue.json への状態記録はレート制限中断後の再開耐性を高める
+
+- lesson_id: agent-crew-sprint-17-reliability-001
+- priority: 3 / sprint: sprint-17
+
+**やること**
+
+各タスク完了時に `_queue.json` の status・summary・events を確実に記録する。レート制限中断後の再開時に、完了済みタスクを重複実行しないために状態記録が必要。
+
+**エビデンス**
+
+Sprint-17 でレート制限による一時中断が発生したが、`_queue.json` の状態記録により重複作業なく再開できた。全タスク retry_count=0（agent-crew-sprint-17-reliability-001）。
+
+---
+
 *このファイルは retro エージェント（みゆきち）が `priority_score >= 3` の新規 lesson を追加するたびに更新されます。*
-*最終更新: sprint-16（Yuki/Riku追記） / 2026-04-26*
+*最終更新: sprint-18 / 2026-04-26*

--- a/.claude/agents/pm-learned-rules.md
+++ b/.claude/agents/pm-learned-rules.md
@@ -472,5 +472,24 @@ Sprint-17 でレート制限による一時中断が発生したが、`_queue.js
 
 ---
 
+## [みゆきち] Issue 作成前に issue_url の重複チェックを実施する
+
+- lesson_id: agent-crew-sprint-18-process-001
+- priority: 4 / sprint: sprint-18
+
+**やること**
+
+retro の Issue 作成手順（ステップ4）で `gh issue create` を実行する前に、`_lessons.json` の `issue_url` が null であることを確認する。null でない場合は Issue 作成をスキップする。
+
+**やってはいけないこと**
+
+同一 lesson_id に対して `issue_url` の確認なしに `gh issue create` を複数回実行する。
+
+**エビデンス**
+
+Sprint-18 で agent-crew-sprint-17-tooling-001 から Issue #99 と #100 が二重生成された。retro.md に重複チェックステップが欠如していたことが根因（Sprint-18 で #99 をクローズして対処）。
+
+---
+
 *このファイルは retro エージェント（みゆきち）が `priority_score >= 3` の新規 lesson を追加するたびに更新されます。*
 *最終更新: sprint-18 / 2026-04-26*

--- a/docs/sprints/sprint-17.md
+++ b/docs/sprints/sprint-17.md
@@ -1,0 +1,99 @@
+# Sprint-17 計画書 / レトロスペクティブ
+
+**期間**: 2026-04-26  
+**ブランチ**: feat/sprint-17  
+**PR**: https://github.com/Andryu/agent-crew/pull/98
+
+---
+
+## ゴール
+
+Issue #61（TaskCompleted hook）の実装、Issue #86（engineer-go 着手条件チェック）の適用、Sprint-16 マージ済み lesson の Issue クローズ処理を完遂する。
+
+---
+
+## スプリント前チェック結果
+
+- [x] 前スプリントの設計完了タスクとの突合: 実施済み（Sprint-16 全4タスク DONE 確認）
+- [x] 計画重複タスク: なし
+- [x] _lessons.json priority >= 6 未解決エントリ確認: sprint-17-tooling-001（新規）・sprint-13-process-001（Issue #86 対応タスクとして sprint-17 で対処）
+
+---
+
+## タスク一覧
+
+| # | slug | タイトル | 担当 | 依存 | complexity | retry | qa_result |
+|---|------|----------|------|------|------------|-------|-----------|
+| 1 | hook-design | TaskCompleted hook 設計書作成 | Alex | なし | M | 0 | — |
+| 2 | lesson-issue-close | PR #93 マージ済み lesson status 更新・Issue #95/#96/#78/#36 クローズ | Yuki | なし | S | 0 | — |
+| 3 | agent-precondition-doc | engineer-go.md 着手条件チェック追記（Issue #86 対応） | Riku | なし | S | 0 | inline |
+| 4 | hook-impl | TaskCompleted hook 実装（task_completed.sh 新規作成・settings.json 更新） | Riku | hook-design | M | 0 | inline |
+| 5 | sprint17-qa | Sprint-17 最終QA | Sora | #3 #4 | S | 0 | APPROVED |
+
+**Riku担当 L タスク**: 0件（制限 1件/sprint に適合）
+
+---
+
+## 今スプリントで起きたこと
+
+### ブロック事象
+
+- **Write 権限不足で Yuki が2回ブロック**: `Write(**)` / `Bash(chmod *)` / `Bash(bash *)` の3権限が settings.json に未登録だった。hook-impl タスク中に判明し、settings.json に追記して対処した。
+- **レート制限による一時中断**: hook-impl 完了直後にレート制限に到達。再開後、sprint17-qa が正常完了した。
+
+### 成功パターン
+
+- _queue.json への状態記録により、レート制限中断後に重複作業なく再開できた（全タスク retry_count=0）。
+- hook-design（Alex）→ hook-impl（Riku）の依存関係（depends_on）が設計通りに機能した。
+- Sora QA が bash -n・jq valid・settings.json hook 登録を実際に確認し APPROVED（全5チェック通過）。
+
+---
+
+## 変更ファイル
+
+| ファイル | 変更種別 |
+|---------|---------|
+| `.claude/hooks/task_completed.sh` | 新規作成 |
+| `.claude/settings.json` | TaskCompleted hook 追加・権限3件追加 |
+| `.claude/agents/engineer-go.md` | 着手条件チェック2箇所追記 |
+| `docs/spec/hook-taskcompleted-design.md` | 新規作成 |
+| `.claude/_queue.json` | Sprint-17 タスク状態記録 |
+| `.claude/_signals.jsonl` | task_completed イベント記録 |
+
+---
+
+## レトロスペクティブ（みゆきち）
+
+### 記録した lesson
+
+| lesson_id | 概要 | priority |
+|-----------|------|----------|
+| agent-crew-sprint-17-tooling-001 | フック実装タスクで権限3件が未登録のまま着手、Yuki が2回ブロック | 6 |
+| agent-crew-sprint-17-reliability-001 | レート制限中断後も _queue.json の状態保持で重複なく再開 | 3 |
+
+### エビデンスゲート結果
+
+| lesson_id | priority_score | evidence 件数 | ゲート通過 |
+|-----------|---------------|--------------|----------|
+| agent-crew-sprint-17-tooling-001 | 6 | 2 | 通過 |
+| agent-crew-sprint-17-reliability-001 | 3 | 2 | 保留（priority < 4） |
+
+### Issue 化
+
+- **作成**: agent-crew-sprint-17-tooling-001 → Issue 作成対象
+- **保留**: agent-crew-sprint-17-reliability-001（priority_score=3）
+
+### pm-learned-rules.md 追記
+
+- 追加: 1件（agent-crew-sprint-17-tooling-001）
+- スキップ（重複）: 0件
+
+---
+
+## 完了条件（達成済み）
+
+- [x] `.claude/hooks/task_completed.sh` が存在し bash -n 構文エラーなし
+- [x] `settings.json` に TaskCompleted hook が登録されている
+- [x] `engineer-go.md` に着手条件チェックルールが2箇所追記されている
+- [x] Sora QA: APPROVED（全5チェック通過）
+- [x] Draft PR #98 作成済み

--- a/docs/sprints/sprint-18.md
+++ b/docs/sprints/sprint-18.md
@@ -1,0 +1,55 @@
+# Sprint-18 計画書
+
+**期間**: 2026-04-26
+**ブランチ**: feat/sprint-18
+**ゴール**: Sprint-17 後処理（Issue 重複整理・lesson status 更新・hook スモークテスト・pm-learned-rules.md コミット）
+
+---
+
+## スプリント前チェック結果
+
+- [x] 前スプリントの設計完了タスクとの突合: 実施済み（Sprint-17 全5タスク DONE・PR #98 マージ済み）
+- [x] 計画重複タスク: なし
+- [x] DECISIONS.md 反映: Sprint-17 の成功パターン（_queue.json 状態記録によるレート制限耐性）を確認。次スプリントへの推奨（Issue #99/#100 重複整理）を sprint-18 に反映。
+- [x] pm-learned-rules.md 反映: sprint-17-tooling-001（フック実装権限事前登録）・sprint-17-reliability-001（_queue.json 状態記録）を確認。sprint-17-tooling-001 は今スプリントでアクション完了（settings.json に権限追加済み・Issue #100 オープン中）。
+- [x] Riku 担当 L タスク: 0件（Riku 担当タスクなし）
+
+---
+
+## タスク一覧
+
+| # | slug | タイトル | 担当 | 依存 | complexity | qa_mode |
+|---|------|----------|------|------|------------|---------|
+| 1 | lesson-dedup-close | Issue #99/#100 重複クローズ + lesson status 更新 | Yuki | なし | S | — |
+| 2 | hook-smoke-test | TaskCompleted hook 実動作確認 | Sora | なし | S | — |
+| 3 | pm-rules-update | pm-learned-rules.md 未コミット変更確定 | Yuki | なし | S | — |
+| 4 | sprint18-qa | Sprint-18 最終QA | Sora | #1 #2 #3 | S | — |
+
+**合計ポイント: 4 pt**（S×4=4）
+**Riku 担当 L タスク**: 0件（制限 1件/sprint に適合）
+
+### 並列化
+
+- lesson-dedup-close・hook-smoke-test・pm-rules-update は同時実行可能（phase-1）
+- sprint18-qa は phase-1 全完了後（phase-2）
+
+---
+
+## 変更ファイル予定
+
+| ファイル | 変更種別 |
+|---------|---------|
+| `.claude/agents/pm-learned-rules.md` | 未コミット変更のコミット + 最終更新日更新 |
+| `.claude/_queue.json` | sprint-18 タスク状態記録 |
+| `~/.claude/_lessons.json` | sprint-17-tooling-001 status を implemented に更新 |
+| `docs/sprints/sprint-18.md` | 本ファイル（新規作成） |
+
+---
+
+## 完了条件
+
+- [ ] Issue #99 が CLOSED
+- [ ] `~/.claude/_lessons.json` の `agent-crew-sprint-17-tooling-001` の status が `implemented`
+- [ ] `.claude/_signals.jsonl` に sprint-17 の `task_completed` イベントが存在する
+- [ ] `pm-learned-rules.md` の最終更新日が sprint-18 に更新されている
+- [ ] Sora QA: APPROVED


### PR DESCRIPTION
## Summary

- Issue #99 クローズ（#100 に統合、sprint-17-tooling-001 からの二重生成 Issue を整理）
- `~/.claude/_lessons.json` の `agent-crew-sprint-17-tooling-001` を `status: implemented` に更新（Sprint-17 で settings.json への権限追加が完了済みのため）
- TaskCompleted hook スモークテスト実施（Sprint-17 で導入した hook の実動作を確認）
- `pm-learned-rules.md` に sprint-17 の2件の lesson エントリを追加・sprint-18 の1件を追記
- レトロ: Issue 重複防止 lesson（sprint-18-process-001）を記録・Issue #102 作成

## Changes

| ファイル | 変更種別 |
|---------|---------|
| `.claude/_queue.json` | sprint-18 タスク状態記録 |
| `.claude/agents/pm-learned-rules.md` | sprint-17/18 lesson 3件追加・最終更新日更新 |
| `docs/sprints/sprint-17.md` | sprint-17 計画書・レトロ記録（新規追加） |
| `docs/sprints/sprint-18.md` | sprint-18 計画書（新規作成） |

## Test plan

- [x] Issue #99 が CLOSED（#100 に統合済み）
- [x] `agent-crew-sprint-17-tooling-001` lesson status = `implemented`
- [x] `task_completed.sh` 実行権限あり・`bash -n` 構文エラーなし
- [x] `_signals.jsonl` に sprint-17 の `task_completed` イベント存在・JSON フィールド有効
- [x] `settings.json` の TaskCompleted hook 登録確認
- [x] `pm-learned-rules.md` に sprint-17/18 の lesson エントリ追加済み
- [x] Sora QA: APPROVED（全5チェック通過）
- [x] レトロ: sprint-18-process-001 記録・Issue #102 作成・pm-learned-rules.md 反映

🤖 Generated with [Claude Code](https://claude.com/claude-code)