### PR TITLE
feat(sprint-21): クロスリポジトリ自律成長基盤 + プライバシー自動チェック（#108 #109 #110 #111）

### DIFF
--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -92,6 +92,34 @@ cat .claude/agents/pm-learned-rules.md
 **ステップ3の「確認事項」に必ず追記する:**
 - [ ] pm-learned-rules.md 反映: [反映したルールの一覧、または「対象なし（理由: ...）」]
 
+### ステップ0.7: 外部リポジトリ教訓の確認（クロスリポジトリ集約）
+
+`~/.claude/_lessons.json` から、agent-crew 以外のリポジトリ由来の未処理教訓を集計する。
+
+```bash
+AGENT_CREW_REPO=$(git remote get-url origin 2>/dev/null || echo "")
+
+jq -r --arg own "$AGENT_CREW_REPO" '
+  [.lessons[] | select(
+    .source_repo != null and
+    .source_repo != $own and
+    .scope == "global" and
+    (.issue_url == null)
+  )] |
+  if length == 0 then
+    "（外部リポジトリ由来の global 教訓なし）"
+  else
+    "外部リポジトリ由来の global 教訓: \(length) 件",
+    (.[] | "  [\(.source_repo | split("/")[-1])] score:\(.priority_score) — \(.description | .[0:60])")
+  end
+' ~/.claude/_lessons.json 2>/dev/null || echo "（_lessons.json が存在しないか読み取り不可）"
+```
+
+確認内容:
+- `scope: global` かつ `source_repo != agent-crew` の未 Issue 化 lesson が 1 件以上ある場合、
+  今スプリントのタスク設計に関連するか確認し、関連するなら計画に取り込む
+- `priority_score >= 6` のものは Issue 化（Issue #111 Plugin Feedback ループ参照）を検討する
+
 ### ステップ1: 前スプリントの実装完了状態の突合
 
 ```bash

--- a/.claude/agents/retro.md
+++ b/.claude/agents/retro.md
@@ -46,9 +46,22 @@ model: sonnet
 ### ステップ 2: `_lessons.json` への記録（flock 経由）
 
 収集した観察を lesson エントリとして `_lessons.json` に追記する。
-その際、対象の知見がどの範囲に適用可能かを判断し、`scope` および `stack` フィールドを適切に付与する。
+その際、対象の知見がどの範囲に適用可能かを判断し、`scope`・`stack`・`source_repo` フィールドを適切に付与する。
 
-#### スコープ（scope）の判断基準
+#### source_repo の取得（必須）
+
+lesson を記録する前に、呼び出し元リポジトリの URL を取得して `source_repo` フィールドに設定する。
+
+```bash
+SOURCE_REPO=$(git remote get-url origin 2>/dev/null || echo "local")
+```
+
+`source_repo` はクロスリポジトリ教訓集約（Issue #110）の基盤フィールドであり、**必ず全 lesson エントリに含める**。
+
+#### スコープ（scope）の判断基準（必須）
+
+`scope` フィールドは **必須**。以下の基準で判定し、省略してはならない。
+
 | scope | 判定基準 | 具体例 |
 |-------|----------|--------|
 | `project` | このプロダクト（リポジトリ）固有のワークフロー、ビジネスロジック、設定の癖 | 「当プロジェクトのデプロイパイプラインでタイムアウトが発生しやすい」 |
@@ -57,9 +70,29 @@ model: sonnet
 
 ※ `scope` が `stack` の場合のみ、該当する技術要素名（例: `"next"`, `"vue"`, `"go"`）を `stack` フィールドに文字列で指定する。それ以外の scope の場合、`stack` は `null` とする。
 
+#### lesson エントリの必須フィールド
+
+```json
+{
+  "id": "...",
+  "project": "...",
+  "source_repo": "https://github.com/owner/repo",
+  "scope": "global | project | stack",
+  "stack": null,
+  ...
+}
+```
+
 書き込み手順：
 
 ```bash
+SOURCE_REPO=$(git remote get-url origin 2>/dev/null || echo "local")
+
+NEW_ENTRY=$(jq -n \
+  --arg source_repo "$SOURCE_REPO" \
+  --arg scope "$SCOPE" \
+  '{ ..., source_repo: $source_repo, scope: $scope }')
+
 (
   flock -x -w 10 200 || { echo "ERROR: lock timeout" >&2; exit 1; }
 
@@ -114,6 +147,50 @@ gh issue create \
 ```
 
 Issue 作成後、`issue_url` を lesson エントリに書き戻す（flock 経由）。
+
+### ステップ 4.5: Plugin Feedback クロスポスト（外部リポジトリ由来の高優先度 global 教訓）
+
+ステップ4完了後、以下の条件を **すべて** 満たす lesson について `agent-crew` リポジトリへのクロスポスト Issue を作成する：
+
+- `source_repo` が agent-crew のリポジトリ URL **以外**
+- `scope == "global"`
+- `priority_score >= 6`
+- `issue_url == null`（まだ Issue 化されていない）
+
+```bash
+AGENT_CREW_REPO="https://github.com/Andryu/agent-crew"
+
+jq -c --arg own "$AGENT_CREW_REPO" '
+  .lessons[] | select(
+    .source_repo != null and
+    .source_repo != $own and
+    .scope == "global" and
+    .priority_score >= 6 and
+    .issue_url == null
+  )
+' ~/.claude/_lessons.json | while IFS= read -r lesson; do
+  LESSON_ID=$(echo "$lesson" | jq -r '.id')
+  TITLE=$(echo "$lesson" | jq -r '.description | .[0:60]')
+  DESCRIPTION=$(echo "$lesson" | jq -r '.description')
+  ACTION=$(echo "$lesson" | jq -r '.action // "調査・対応を検討"')
+  PRIORITY=$(echo "$lesson" | jq -r '.priority_score')
+  SOURCE=$(echo "$lesson" | jq -r '.source_repo')
+
+  CROSSPOST_URL=$(gh issue create \
+    --repo Andryu/agent-crew \
+    --title "[plugin-feedback] ${TITLE}" \
+    --body "## 発生元リポジトリ\n\n${SOURCE}\n\n## 観察された問題\n\n${DESCRIPTION}\n\n## 推奨アクション\n\n${ACTION}\n\n---\n*lesson ID: ${LESSON_ID} / priority: ${PRIORITY} / scope: global*\n*このIssueは みゆきち（retro エージェント）が Plugin Feedback フローで自動生成しました。*" \
+    --label "plugin-feedback" \
+    --label "retro" \
+    --label "lessons-learned" 2>/dev/null || echo "")
+
+  if [[ -n "$CROSSPOST_URL" ]]; then
+    echo "  [plugin-feedback] クロスポスト: $CROSSPOST_URL"
+  fi
+done
+```
+
+クロスポスト後、`plugin_feedback_url` を lesson エントリに書き戻すことを推奨（任意）。
 
 ### ステップ 5: `pm-learned-rules.md` へのルール書き出し
 

--- a/.claude/hooks/session_start.sh
+++ b/.claude/hooks/session_start.sh
@@ -18,7 +18,8 @@ if ! command -v jq >/dev/null 2>&1; then
 fi
 
 # ---------- 3. 設定 ----------
-QUEUE_FILE=".claude/_queue.json"
+PROJECT_ROOT="${CLAUDE_PROJECT_ROOT:-$(git rev-parse --show-toplevel 2>/dev/null || pwd)}"
+QUEUE_FILE="${QUEUE_FILE:-${PROJECT_ROOT}/.claude/_queue.json}"
 LESSONS_FILE="${HOME}/.claude/_lessons.json"
 
 # プロジェクト名取得（git remote → ディレクトリ名フォールバック）

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -48,6 +48,15 @@
             "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null)\" && scripts/propose-lesson-rules.sh --dry-run 2>/dev/null || true'"
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'cd \"$(git rev-parse --show-toplevel 2>/dev/null)\" && bash scripts/privacy-check.sh 2>/dev/null || true'"
+          }
+        ]
       }
     ]
   },
@@ -72,6 +81,7 @@
       "Bash(jq *)",
       "Bash(chmod *)",
       "Bash(bash *)",
+      "Bash(scripts/privacy-check.sh *)",
       "Write(**)"
     ]
   }

--- a/.claude/skills/privacy-audit/SKILL.md
+++ b/.claude/skills/privacy-audit/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: privacy-audit
+description: >-
+  リポジトリ内の個人情報・機密情報の漏洩リスクを検査するスキル。
+  「個人情報チェック」「プライバシー監査」「情報漏洩チェック」
+  「公開前に確認して」「個人情報が含まれていないか調べて」
+  のような指示で起動。git 追跡ファイル全体をスキャンし、
+  🔴 CRITICAL / 🟡 WARNING / 🟢 INFO で分類して報告する。
+  公開リポジトリへの push 前・プラグイン配布前に実行推奨。
+---
+
+# Privacy Audit Skill
+
+## ワークフロー（5ステップ）
+
+### ステップ 1: git 追跡ファイルの一覧取得
+
+```bash
+git ls-files
+```
+
+スキャン対象: `git ls-files` で列挙されたすべてのテキストファイル。  
+除外: `.git/`、`node_modules/`、バイナリファイル、`*.lock`、`.env`（未追跡であれば問題なし）
+
+### ステップ 2: 差分ファイルへのパターンスキャン（自動チェック分）
+
+```bash
+bash scripts/privacy-check.sh
+```
+
+自動スキャンが対象とするパターン:
+- メールアドレス（`@` を含むもの）
+- 絶対パス（`/Users/<username>/` 等のユーザー名を含むもの）
+- Slack Webhook URL（`hooks.slack.com/services/`）
+- GitHub PAT（`ghp_` プレフィックス）
+- OpenAI / Anthropic API キー
+- 日本の電話番号パターン
+
+### ステップ 3: .gitignore の漏れチェック
+
+以下のファイルが git 追跡対象になっていないか確認する:
+
+```bash
+git ls-files | grep -E '(settings\.local\.json|\.env|credentials|\.secret|_lessons\.json)' || echo "（対象ファイルなし）"
+```
+
+危険なファイルが追跡対象の場合は 🔴 CRITICAL として報告する。
+
+### ステップ 4: git 履歴の直近 50 コミットをスキャン
+
+```bash
+git log --oneline -50
+```
+
+コミットメッセージに実名・メールアドレス・電話番号が含まれていないか目視確認する。
+
+### ステップ 5: 結果を分類して報告
+
+以下の形式でレポートを出力する:
+
+```
+## プライバシー監査結果
+
+### 🔴 CRITICAL（即時対応が必要）
+- ファイル: 内容（コミット前に削除または .gitignore 追加が必須）
+
+### 🟡 WARNING（公開前に確認推奨）
+- ファイル: 内容（意図的な場合は除外設定を見直す）
+
+### 🟢 INFO（懸念なし）
+- 検出なし / 検出内容と判断理由
+
+### 総合判定: SAFE / REVIEW_NEEDED / UNSAFE
+```
+
+## 補足
+
+- Stop フック（セッション終了時）でも `scripts/privacy-check.sh` が差分ファイルに対して自動実行される
+- このスキルは **全追跡ファイル** を対象とした手動・定期的な包括監査用
+- 公開リポジトリへの push 前、または `claude plugin install` で配布前に実行することを推奨

--- a/install.sh
+++ b/install.sh
@@ -13,6 +13,7 @@
 # スキルはネームスペース付きで利用可能:
 #   /agent-crew:life-planner
 #   /agent-crew:life-plan-review
+#   /agent-crew:privacy-audit
 #
 # このスクリプトは開発環境セットアップ用途（git hooks・
 # スクリプト権限付与・グローバルシンボリックリンク配置）

--- a/scripts/privacy-check.sh
+++ b/scripts/privacy-check.sh
@@ -1,0 +1,75 @@
+#!/bin/bash
+# scripts/privacy-check.sh
+# 変更ファイルに個人情報パターンが含まれていないかスキャンする
+# Stop フックから自動実行 + /privacy-audit スキルから手動実行
+
+set -euo pipefail
+
+FOUND=0
+
+# スキャン対象: git で変更されたファイル（未コミット差分 + ステージ済み）
+CHANGED_FILES=$(git diff --name-only HEAD 2>/dev/null; git diff --name-only --cached 2>/dev/null)
+CHANGED_FILES=$(echo "$CHANGED_FILES" | sort -u | grep -v '^\s*$' || true)
+
+if [[ -z "$CHANGED_FILES" ]]; then
+  exit 0
+fi
+
+# スキャン対象外パターン
+EXCLUDE_PATTERNS=(
+  "^\.git/"
+  "\.lock$"
+  "^node_modules/"
+  "\.claude/settings\.local\.json$"
+  "^\.env"
+)
+
+# 個人情報検出パターン
+declare -A PATTERNS
+PATTERNS["メールアドレス"]='[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}'
+PATTERNS["絶対パス(ユーザー名)"]='/Users/[a-zA-Z0-9_\-]+/'
+PATTERNS["Slack Webhook"]='hooks\.slack\.com/services/'
+PATTERNS["GitHub PAT"]='ghp_[A-Za-z0-9]{36}'
+PATTERNS["OpenAI APIキー"]='sk-[A-Za-z0-9]{48}'
+PATTERNS["Anthropic APIキー"]='sk-ant-[A-Za-z0-9\-]+'
+PATTERNS["電話番号(日本)"]='(0[789]0[-\s]?[0-9]{4}[-\s]?[0-9]{4}|0[0-9]{1,4}[-\s]?[0-9]{1,4}[-\s]?[0-9]{4})'
+
+while IFS= read -r file; do
+  [[ -z "$file" ]] && continue
+  [[ ! -f "$file" ]] && continue
+
+  # 除外対象ファイルをスキップ
+  SKIP=0
+  for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+    if echo "$file" | grep -qE "$pattern"; then
+      SKIP=1
+      break
+    fi
+  done
+  [[ $SKIP -eq 1 ]] && continue
+
+  # バイナリファイルをスキップ
+  if file "$file" 2>/dev/null | grep -q "binary"; then
+    continue
+  fi
+
+  for label in "${!PATTERNS[@]}"; do
+    pattern="${PATTERNS[$label]}"
+    matches=$(grep -nE "$pattern" "$file" 2>/dev/null || true)
+    if [[ -n "$matches" ]]; then
+      echo "⚠️  WARNING [$label] $file" >&2
+      echo "$matches" | head -3 | while IFS= read -r line; do
+        echo "   $line" >&2
+      done
+      FOUND=1
+    fi
+  done
+done <<< "$CHANGED_FILES"
+
+if [[ $FOUND -eq 1 ]]; then
+  echo "" >&2
+  echo "個人情報の可能性があるパターンが検出されました。コミット前に確認してください。" >&2
+  echo "意図的な場合: git commit に --no-verify は使わず、.gitignore または除外パターンを見直してください。" >&2
+fi
+
+exit 0

--- a/scripts/setup-sprint.sh
+++ b/scripts/setup-sprint.sh
@@ -1,0 +1,121 @@
+#!/bin/bash
+# scripts/setup-sprint.sh
+# 別リポジトリへのスプリント管理機能セットアップスクリプト
+#
+# 使い方:
+#   bash /path/to/agent-crew/scripts/setup-sprint.sh [TARGET_REPO_PATH] [SPRINT_NAME]
+#
+# 例:
+#   bash ~/Workspace/agent-crew/scripts/setup-sprint.sh . sprint-1
+#   bash ~/Workspace/agent-crew/scripts/setup-sprint.sh ~/Workspace/my-project
+
+set -euo pipefail
+
+AGENT_CREW_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TARGET="${1:-.}"
+SPRINT_NAME="${2:-sprint-1}"
+
+# --help
+if [[ "${1:-}" == "--help" ]] || [[ "${1:-}" == "-h" ]]; then
+  cat <<EOF
+使い方: $0 [TARGET_REPO_PATH] [SPRINT_NAME]
+
+  TARGET_REPO_PATH  スプリント機能を追加するリポジトリのパス（デフォルト: カレントディレクトリ）
+  SPRINT_NAME       初期スプリント名（デフォルト: sprint-1）
+
+例:
+  $0 .                                    # カレントディレクトリに追加
+  $0 ~/Workspace/my-project sprint-1     # 別リポジトリに追加
+
+実行内容:
+  1. TARGET/.claude/hooks/ にスプリントフックをシンボリックリンク
+  2. TARGET/.claude/_queue.json が存在しない場合、空のキューを作成
+  3. TARGET/.claude/settings.json に hooks エントリを追記（存在しない場合は新規作成）
+EOF
+  exit 0
+fi
+
+TARGET="$(cd "$TARGET" && pwd)"
+
+echo "=== agent-crew スプリント機能セットアップ ==="
+echo "対象リポジトリ: $TARGET"
+echo "agent-crew:     $AGENT_CREW_DIR"
+echo "スプリント名:    $SPRINT_NAME"
+echo ""
+
+# ---------- 1. .claude/hooks/ にシンボリックリンクを作成 ----------
+HOOKS_DIR="$TARGET/.claude/hooks"
+mkdir -p "$HOOKS_DIR"
+
+for hook in task_completed subagent_stop session_start; do
+  SRC="$AGENT_CREW_DIR/.claude/hooks/${hook}.sh"
+  DST="$HOOKS_DIR/${hook}.sh"
+  if [[ ! -f "$SRC" ]]; then
+    echo "WARN: $SRC が見つかりません。スキップします。" >&2
+    continue
+  fi
+  if [[ -L "$DST" ]]; then
+    echo "  [SKIP]    $DST (既にシンボリックリンク済み)"
+  else
+    ln -sf "$SRC" "$DST"
+    echo "  [SYMLINK] $DST -> $SRC"
+  fi
+done
+echo ""
+
+# ---------- 2. _queue.json が存在しない場合に作成 ----------
+QUEUE_FILE="$TARGET/.claude/_queue.json"
+if [[ -f "$QUEUE_FILE" ]]; then
+  echo "  [SKIP]    $QUEUE_FILE (既に存在)"
+else
+  cat > "$QUEUE_FILE" <<QUEUEEOF
+{
+  "sprint": "${SPRINT_NAME}",
+  "tasks": []
+}
+QUEUEEOF
+  echo "  [CREATE]  $QUEUE_FILE"
+fi
+echo ""
+
+# ---------- 3. settings.json に hooks エントリを追記 ----------
+SETTINGS_FILE="$TARGET/.claude/settings.json"
+
+HOOKS_SNIPPET=$(cat <<'SNIPPET'
+{
+  "hooks": {
+    "TaskCompleted": [
+      { "hooks": [{ "type": "command", "command": ".claude/hooks/task_completed.sh" }] }
+    ],
+    "SubagentStop": [
+      { "hooks": [{ "type": "command", "command": ".claude/hooks/subagent_stop.sh" }] }
+    ],
+    "Stop": [
+      { "hooks": [{ "type": "command", "command": ".claude/hooks/subagent_stop.sh" }] }
+    ]
+  }
+}
+SNIPPET
+)
+
+if [[ -f "$SETTINGS_FILE" ]]; then
+  MERGED=$(jq -s '.[0] * .[1]' "$SETTINGS_FILE" <(echo "$HOOKS_SNIPPET") 2>/dev/null || echo "")
+  if [[ -n "$MERGED" ]]; then
+    echo "$MERGED" > "$SETTINGS_FILE"
+    echo "  [MERGE]   $SETTINGS_FILE に hooks エントリを追記"
+  else
+    echo "WARN: settings.json のマージに失敗しました。手動で hooks を追加してください。" >&2
+  fi
+else
+  mkdir -p "$(dirname "$SETTINGS_FILE")"
+  echo "$HOOKS_SNIPPET" > "$SETTINGS_FILE"
+  echo "  [CREATE]  $SETTINGS_FILE"
+fi
+echo ""
+
+echo "=== セットアップ完了 ==="
+echo ""
+echo "次のステップ:"
+echo "  1. $QUEUE_FILE にタスクを追加"
+echo "  2. Claude Code でこのリポジトリを開いてスプリントを開始"
+echo "  3. pm エージェントを呼んで計画を立てる"


### PR DESCRIPTION
## Summary

- **#110**: `_lessons.json` に `source_repo` + `scope` 必須フィールドを追加。他リポジトリで発生した教訓が agent-crew に自動集約される基盤を構築
- **#111**: Plugin Feedback クロスポストフロー — `scope=global` かつ `priority_score>=6` の外部リポジトリ教訓を agent-crew Issue に自動クロスポスト（`retro.md` ステップ4.5）
- **#108**: `scripts/privacy-check.sh` + `/privacy-audit` スキル + Stop フック自動実行でプライバシーチェックを常時監視
- **#109**: `session_start.sh` の `QUEUE_FILE` ハードコード除去（動的パス解決）+ `scripts/setup-sprint.sh` 汎用インストーラで別リポジトリへのスプリント機能展開が可能に

### 自律成長ループ（完成後のフロー）

```
alpha-predict-jp でエージェントが作業
  → retro 呼び出し → _lessons.json に source_repo 付きで記録
  → scope=global && priority>=6 → agent-crew Issue に自動クロスポスト
  → 次スプリント前に Yuki がステップ0.7 で外部教訓を確認
  → agent-crew 自身が改善スプリントを計画
```

## Test plan

- [x] retro.md: source_repo 取得コードあり（ステップ2）
- [x] retro.md: scope フィールドが必須と明記
- [x] retro.md: Plugin Feedback クロスポスト（ステップ4.5）あり
- [x] pm.md: ステップ0.7（外部教訓集計）あり
- [x] scripts/privacy-check.sh: 実行可能・bash -n SYNTAX OK・パターン5種以上
- [x] .claude/skills/privacy-audit/SKILL.md: 5ステップワークフロー記述あり
- [x] settings.json: Stop フックに privacy-check.sh 追加
- [x] settings.json: permissions.allow に Bash(scripts/privacy-check.sh *) 追加
- [x] session_start.sh: QUEUE_FILE 動的解決（ハードコードなし）
- [x] scripts/setup-sprint.sh: 実行可能・bash -n SYNTAX OK
- [x] Sora QA: APPROVED（全10項目）

Closes #108
Closes #109
Closes #110
Closes #111

🤖 Generated with [Claude Code](https://claude.com/claude-code)