### PR TITLE
feat(bridge): 教訓のvault自動転記と想起フック

### DIFF
--- a/.claude/hooks/subagent_stop.sh
+++ b/.claude/hooks/subagent_stop.sh
@@ -141,6 +141,11 @@ if [[ "$INCOMPLETE" == "0" && "$QA_PENDING" == "0" ]]; then
       -H 'Content-type: application/json' \
       -d "{\"text\": \"$MESSAGE\"}" >/dev/null 2>&1
   fi
+
+  # ---------- 4. 高優先度教訓のvault転記（失敗しても以降の処理に影響させない） ----------
+  HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  REPO_ROOT="$(cd "${HOOK_DIR}/../.." && pwd)"
+  bash "${REPO_ROOT}/scripts/lessons-to-vault.sh" || true
 fi
 
 exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -58,6 +58,16 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "echo 'スプリント計画・レトロの前に必読: ~/Workspace/Obsidian/knowledge/agent-crew-failure-patterns.md（繰り返し失敗パターン）と ~/Workspace/Obsidian/decisions/agent-crew-adr-index.md（ADR索引）'"
+          }
+        ]
+      }
     ]
   },
   "permissions": {

--- a/scripts/lessons-to-vault.sh
+++ b/scripts/lessons-to-vault.sh
@@ -5,11 +5,15 @@
 # 高優先度（priority_score >= MIN_PRIORITY）の教訓をスプリント単位でグループ化し、
 # $VAULT_DIR/inbox/agent-crew-lessons-<sprint>.md として書き出す。
 # 出力ファイルが既に存在するスプリントはスキップする（再実行しても重複生成しない）。
+# sprint-23 以前の教訓は knowledge/agent-crew-failure-patterns.md に統合済みのため、
+# MIN_SPRINT のデフォルトで転記対象から除外する（inbox への重複ノイズ投入を防ぐ）。
 #
 # 環境変数:
 #   VAULT_DIR      知識vaultのルート (default: $HOME/Workspace/Obsidian)
 #   LESSONS_FILE   教訓ファイルパス (default: $HOME/.claude/_lessons.json)
 #   MIN_PRIORITY   転記対象の最小 priority_score (default: 4)
+#   MIN_SPRINT     転記対象の最小スプリント番号。sprint 名末尾の数値でフィルタする。
+#                  数値をパースできない sprint 名は安全側で転記対象に含める (default: 24)
 #
 # フックチェーン（SubagentStop 等）から呼ばれても他の処理に影響しないよう、
 # 前提条件が満たされない場合も含め、いかなる場合も exit 0 とする。
@@ -19,6 +23,7 @@ set -uo pipefail
 VAULT_DIR="${VAULT_DIR:-$HOME/Workspace/Obsidian}"
 LESSONS_FILE="${LESSONS_FILE:-$HOME/.claude/_lessons.json}"
 MIN_PRIORITY="${MIN_PRIORITY:-4}"
+MIN_SPRINT="${MIN_SPRINT:-24}"
 
 warn() {
   echo "WARN: lessons-to-vault.sh: $*" >&2
@@ -46,8 +51,25 @@ if ! [[ "$MIN_PRIORITY" =~ ^[0-9]+$ ]]; then
   exit 0
 fi
 
+if ! [[ "$MIN_SPRINT" =~ ^[0-9]+$ ]]; then
+  warn "MIN_SPRINT は数値で指定してください（got: '$MIN_SPRINT'）。スキップします。"
+  exit 0
+fi
+
 INBOX_DIR="$VAULT_DIR/inbox"
 mkdir -p "$INBOX_DIR" 2>/dev/null || { warn "$INBOX_DIR を作成できません。スキップします。"; exit 0; }
+
+# sprint 名の末尾数値が MIN_SPRINT 未満なら除外する。
+# 末尾が数値でない sprint 名は安全側（未知の命名を黙って捨てない）で対象に含める。
+sprint_included() {
+  local sprint="$1"
+  if [[ "$sprint" =~ ([0-9]+)$ ]]; then
+    local n=$((10#${BASH_REMATCH[1]}))
+    [[ "$n" -ge "$MIN_SPRINT" ]]
+    return
+  fi
+  return 0
+}
 
 # ---------- 対象スプリントの抽出 ----------
 
@@ -66,9 +88,15 @@ fi
 TODAY=$(date +%Y-%m-%d)
 GENERATED=0
 SKIPPED=0
+EXCLUDED=0
 
 while IFS= read -r SPRINT; do
   [[ -z "$SPRINT" ]] && continue
+
+  if ! sprint_included "$SPRINT"; then
+    EXCLUDED=$((EXCLUDED + 1))
+    continue
+  fi
 
   OUT_FILE="$INBOX_DIR/agent-crew-lessons-${SPRINT}.md"
 
@@ -123,6 +151,6 @@ while IFS= read -r SPRINT; do
   GENERATED=$((GENERATED + 1))
 done <<< "$SPRINTS"
 
-echo "lessons-to-vault: 生成 ${GENERATED} 件 / スキップ（既存） ${SKIPPED} 件"
+echo "lessons-to-vault: 生成 ${GENERATED} 件 / スキップ（既存） ${SKIPPED} 件 / 除外（MIN_SPRINT未満） ${EXCLUDED} 件"
 
 exit 0

--- a/scripts/lessons-to-vault.sh
+++ b/scripts/lessons-to-vault.sh
@@ -1,0 +1,128 @@
+#!/bin/bash
+# scripts/lessons-to-vault.sh
+# 教訓（~/.claude/_lessons.json）を知識vaultの inbox へ自動転記する
+#
+# 高優先度（priority_score >= MIN_PRIORITY）の教訓をスプリント単位でグループ化し、
+# $VAULT_DIR/inbox/agent-crew-lessons-<sprint>.md として書き出す。
+# 出力ファイルが既に存在するスプリントはスキップする（再実行しても重複生成しない）。
+#
+# 環境変数:
+#   VAULT_DIR      知識vaultのルート (default: $HOME/Workspace/Obsidian)
+#   LESSONS_FILE   教訓ファイルパス (default: $HOME/.claude/_lessons.json)
+#   MIN_PRIORITY   転記対象の最小 priority_score (default: 4)
+#
+# フックチェーン（SubagentStop 等）から呼ばれても他の処理に影響しないよう、
+# 前提条件が満たされない場合も含め、いかなる場合も exit 0 とする。
+
+set -uo pipefail
+
+VAULT_DIR="${VAULT_DIR:-$HOME/Workspace/Obsidian}"
+LESSONS_FILE="${LESSONS_FILE:-$HOME/.claude/_lessons.json}"
+MIN_PRIORITY="${MIN_PRIORITY:-4}"
+
+warn() {
+  echo "WARN: lessons-to-vault.sh: $*" >&2
+}
+
+# ---------- 前提チェック（満たさない場合は警告のみで exit 0） ----------
+
+if ! command -v jq >/dev/null 2>&1; then
+  warn "jq not found. スキップします。"
+  exit 0
+fi
+
+if [[ ! -f "$LESSONS_FILE" ]]; then
+  warn "$LESSONS_FILE が見つかりません。スキップします。"
+  exit 0
+fi
+
+if [[ ! -d "$VAULT_DIR" ]]; then
+  warn "vault ディレクトリ $VAULT_DIR が見つかりません。スキップします。"
+  exit 0
+fi
+
+if ! [[ "$MIN_PRIORITY" =~ ^[0-9]+$ ]]; then
+  warn "MIN_PRIORITY は数値で指定してください（got: '$MIN_PRIORITY'）。スキップします。"
+  exit 0
+fi
+
+INBOX_DIR="$VAULT_DIR/inbox"
+mkdir -p "$INBOX_DIR" 2>/dev/null || { warn "$INBOX_DIR を作成できません。スキップします。"; exit 0; }
+
+# ---------- 対象スプリントの抽出 ----------
+
+SPRINTS=$(jq -r --argjson mp "$MIN_PRIORITY" '
+  [.lessons[]? | select((.priority_score // 0) >= $mp) | .sprint]
+  | map(select(. != null and . != ""))
+  | unique
+  | .[]
+' "$LESSONS_FILE" 2>/dev/null)
+
+if [[ -z "$SPRINTS" ]]; then
+  echo "lessons-to-vault: MIN_PRIORITY=$MIN_PRIORITY 以上の教訓が見つかりませんでした。"
+  exit 0
+fi
+
+TODAY=$(date +%Y-%m-%d)
+GENERATED=0
+SKIPPED=0
+
+while IFS= read -r SPRINT; do
+  [[ -z "$SPRINT" ]] && continue
+
+  OUT_FILE="$INBOX_DIR/agent-crew-lessons-${SPRINT}.md"
+
+  # 冪等性: 既に生成済みのスプリントはスキップ
+  if [[ -f "$OUT_FILE" ]]; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  LESSON_LINES=$(jq -c --arg sprint "$SPRINT" --argjson mp "$MIN_PRIORITY" '
+    .lessons[]?
+    | select(.sprint == $sprint and ((.priority_score // 0) >= $mp))
+    | {id, priority_score, category, type, description, action}
+  ' "$LESSONS_FILE" 2>/dev/null)
+
+  [[ -z "$LESSON_LINES" ]] && continue
+
+  {
+    echo "---"
+    echo "title: agent-crew ${SPRINT} の教訓候補"
+    echo "type: inbox"
+    echo "tags: [agent-crew, lessons]"
+    echo "source: ~/.claude/_lessons.json から自動転記"
+    echo "updated: ${TODAY}"
+    echo "---"
+    echo ""
+    echo "# agent-crew ${SPRINT} の教訓候補"
+    echo ""
+  } > "$OUT_FILE"
+
+  while IFS= read -r LESSON; do
+    [[ -z "$LESSON" ]] && continue
+    ID=$(jq -r '.id // "unknown"' <<< "$LESSON")
+    PRIORITY=$(jq -r '.priority_score // "?"' <<< "$LESSON")
+    CATEGORY=$(jq -r '.category // "unknown"' <<< "$LESSON")
+    TYPE=$(jq -r '.type // "unknown"' <<< "$LESSON")
+    DESCRIPTION=$(jq -r '.description // ""' <<< "$LESSON")
+    ACTION=$(jq -r '.action // ""' <<< "$LESSON")
+
+    {
+      echo "## ${ID}"
+      echo "- priority_score: ${PRIORITY}"
+      echo "- category/type: ${CATEGORY} / ${TYPE}"
+      echo "- description: ${DESCRIPTION}"
+      if [[ -n "$ACTION" ]]; then
+        echo "- action: ${ACTION}"
+      fi
+      echo ""
+    } >> "$OUT_FILE"
+  done <<< "$LESSON_LINES"
+
+  GENERATED=$((GENERATED + 1))
+done <<< "$SPRINTS"
+
+echo "lessons-to-vault: 生成 ${GENERATED} 件 / スキップ（既存） ${SKIPPED} 件"
+
+exit 0


### PR DESCRIPTION
## 背景

agent-crewの最大の失敗パターンは「教訓を `~/.claude/_lessons.json` に記録する仕組みはあるが、想起する導線がない」こと（Sprint-08の教訓がSprint-09の計画に反映されなかった等）。これを記録側と想起側の両方から閉じる。

- 記録側: 高優先度の教訓を知識vault `~/Workspace/Obsidian/inbox/` に候補ノートとして自動転記
- 想起側: agent-crewのセッション開始時に、vaultの失敗パターン集への参照をコンテキスト注入

## 変更点

### 1. `scripts/lessons-to-vault.sh`（新規）
- `_lessons.json` の `lessons[]` から `priority_score >= MIN_PRIORITY`（デフォルト4）かつスプリント番号が `MIN_SPRINT`（デフォルト24）以上の教訓をスプリント単位でグループ化し、`$VAULT_DIR/inbox/agent-crew-lessons-<sprint>.md` を生成
- `MIN_SPRINT`: sprint-23以前の教訓は既に `knowledge/agent-crew-failure-patterns.md` に統合済みのため、デフォルトで転記対象から除外（inboxへの重複ノイズ投入を防ぐ）。sprint名末尾の数値でフィルタし、数値をパースできないsprint名は安全側で対象に含める
- 出力ファイルが既に存在するスプリントはスキップする（冪等）
- vaultが存在しない・jqがない・MIN_PRIORITY/MIN_SPRINTが非数値等の前提条件未達時は警告のみでexit 0（フックチェーンから呼ばれても安全）

### 2. `.claude/settings.json`
- `hooks.SessionStart` を新規追加し、vaultの失敗パターン集（`agent-crew-failure-patterns.md`）とADR索引（`agent-crew-adr-index.md`）への参照をセッション開始時にecho（stdout経由でコンテキスト注入）
- 既存の `TaskCompleted` / `PreToolUse` / `SubagentStop` / `Stop` は変更なし（diffで純追加であることを確認済み）

### 3. `.claude/hooks/subagent_stop.sh`
- スプリント完了判定ブロック（`INCOMPLETE==0 && QA_PENDING==0`）の末尾に `scripts/lessons-to-vault.sh` の呼び出しを追記
- `|| true` でガードし、失敗しても既存のSlack通知・次ステップ提示処理には一切影響しない
- リポジトリルートを `BASH_SOURCE` から解決するため、カレントディレクトリに依存しない

## レビュー指摘への対応（開発中に発生したインシデントの記録）

レビュー中、`scripts/lessons-to-vault.sh` を初回デフォルト（MIN_PRIORITY=4のみ・MIN_SPRINT未実装）でトリガーすると、既にvaultの `knowledge/agent-crew-failure-patterns.md` に統合済みのsprint-23以前の教訓まで一斉に `inbox/` へ再投入されてしまう設計上の問題が指摘された。さらに検証作業中、この開発ワークツリーの `.claude/settings.json` / `.claude/hooks/subagent_stop.sh` が本セッションの「実際に動作するフック設定」として読み込まれていたため、意図的なテスト（`VAULT_DIR` を明示的に一時ディレクトリへ上書きして実行したもの）とは別に、セッション内の実際のSubagentStopイベント発火時にデフォルト値（`VAULT_DIR` 上書きなし）で本物の `~/Workspace/Obsidian/inbox/` に15件のノートが書き込まれてしまった（レビュー担当が発見・削除済み、実害なし）。

**根本原因**: 開発ワークツリーであっても `.claude/settings.json` に組み込んだフックは、そのワークツリーで実際に発生するSubagentStopイベントに対して即座に「本番同様」動作する。明示的に `VAULT_DIR` を渡した手動テストはすべて安全だったが、それとは別に本物のフック発火（環境変数の上書きが効かない実行経路）が発生し得ることを見落としていた。

**恒久対応**: `MIN_SPRINT`（デフォルト24）を追加。現在の実際のスプリントはsprint-23であり、24未満のため `MIN_SPRINT` の既定値だけで「本物のフックがデフォルト設定のまま発火しても対象0件になる」状態になる。これにより、今回と同種の事故は本PRの変更そのものによって再発しない構造になった。

**再発防止ルール**: `subagent_stop.sh` を直接実行して検証する場合は、以後必ず `VAULT_DIR`（および必要に応じて `QUEUE_FILE` / `LESSONS_FILE`）を一時ディレクトリへ明示的に export してから実行する。

## Test Plan

- [x] `lessons-to-vault.sh` を `VAULT_DIR=<scratchpadの一時ディレクトリ>` で実ファイル `~/.claude/_lessons.json` に対して実行し、生成ノートの中身を確認
  - MIN_PRIORITY=4（デフォルト・MIN_SPRINT未指定時は0）で15スプリント分のノートを生成、内容（frontmatter・priority_score・category/type・description・action）を目視確認
- [x] 2回目の実行で新規生成0件・全スキップとなること（冪等性）を確認
- [x] `MIN_PRIORITY=9` で対象が2スプリントに絞られることを確認
- [x] vault不在・lessonsファイル不在時に警告のみでexit 0となることを確認
- [x] `.claude/settings.json` がjqで有効なJSONとしてパースできることを確認
- [x] `git diff` で既存hooksエントリ（TaskCompleted/PreToolUse/SubagentStop/Stop）が変更されていないこと（純追加のみ）を確認
- [x] `bash -n` で `lessons-to-vault.sh` / `subagent_stop.sh` の構文チェック
- [x] `subagent_stop.sh` をテスト用queue.json + `VAULT_DIR`一時ディレクトリで実行し、既存のスプリント完了バナー・NEXT STEP提示が壊れておらず、末尾でvault転記が実行されることを確認
- [x] **MIN_SPRINT追加後の再検証**: デフォルト（MIN_SPRINT=24）で実 `~/.claude/_lessons.json`（最大sprint-23）に対して一時VAULT_DIRで実行 → 生成0件を確認
- [x] `MIN_SPRINT=8 MIN_PRIORITY=6` で対象が8スプリントに絞られた生成になることを確認、sprint名が末尾数値でない場合も安全側（対象に含める）で動作することを合成データで確認
- [x] **インシデント後の実vault無傷確認**: `ls ~/Workspace/Obsidian/inbox/` に `agent-crew-*` ファイルが存在しないことを確認（レビュー担当による削除後、本PRでの追加検証作業でも再発なし）。実デフォルト値での再実行によるライブ確認は、ハーネスの自動モード分類器により実パス操作としてブロックされたため実施していない（意図的にガードを回避しなかった）。代わりにjqドライランで実データに対しMIN_SPRINT=24条件で対象0件であることを数値的に確認した

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AFkHh2cV2MEzTDsZCRc5sc
