### PR TITLE
fix: lessons から agent .md へ禁止パターンを自動提案 (2026-08-02)

### DIFF
--- a/.claude/agents/engineer-go.md
+++ b/.claude/agents/engineer-go.md
@@ -386,3 +386,43 @@ Yuki へは `BLOCKED` ステータスとともにキューの notes へ詳細を
 - **lesson**: Sprint-15 の retro フェーズで scripts/lessons.sh が permissions.allow に未登録であり、lesson 記録（lessons.sh add）が実行できなかった。
 - **禁止行動**: 
 - **priority**: 4 / sprint: sprint-15
+
+### agent-crew-sprint-21-tooling-001
+- **lesson**: Claude Code には Cron フック（定期実行フック）が存在しない。Sprint-21 でリサーチエージェント（Alex/Yuki/Guide）がリサーチを行った結果、この技術的制約を事前に発見し、Stop フック（セッション終了
+- **禁止行動**: 定期実行を必要とする機能を設計する際は、Claude Code の利用可能なフックタイプ（Stop/PreToolCall/PostToolCall 等）を事前にリサーチし、Cron 相当機能がないことを前提に設計する。Stop フックはセッション終了トリガーとして利用可能。
+- **priority**: 4 / sprint: sprint-21
+
+### agent-crew-sprint-22-tooling-001
+- **lesson**: Sprint-22 でグローバル学習ログフック（capture-learning.sh / aggregate-learnings.sh）を実装したが、~/.claude/settings.json への SubagentStop/Stop
+- **禁止行動**: フックの install.sh オプションを実装した場合、CI または QA タスクの notes に「実際に install.sh --only=global-hooks を実行して ~/.claude/settings.json を確認する」テスト手順を明記する。手動セットアップが必要な実装は「APPROVED_WITH_NOTE の NOTE 内容をスプリント完了条件に含める」ことで積み残し防止を図る。
+- **priority**: 4 / sprint: sprint-22
+
+### agent-crew-sprint-24-tooling-001
+- **lesson**: Renがtoken-report-scriptの実データ調査で、JSONLのストリーミング途中経過行を単純合算するとトークン消費が2〜5倍水増しされる落とし穴を発見し、message.idでの重複排除により回避した。想像でスキーマを設計せず
+- **禁止行動**: JSONLやログなど、ストリーミング形式で書き出されるデータを集計するスクリプトは、実装前に実データのフィールド構造・重複パターンを確認してからスキーマを設計する。実装後は必ず実データで実行し、レコードの重複（途中経過行の重複合算等）による水増しが発生していないかを検証する。
+- **priority**: 4 / sprint: sprint-24
+
+### agent-crew-sprint-26-tooling-001
+- **lesson**: queue.py の仕様上 qa_result は上書きできず、done 側にも重複記録のガードがない。そのためQA再判定（CHANGES_REQUESTED→修正→APPROVED）の正規の記録経路が retry コマンドしか存在せず、S
+- **禁止行動**: queue.py に qa --force（既存qa_resultを上書きしてQA再判定を記録する）オプション、または done 側に「qa_result != null かつ再QAの場合は retry を使わず再記録できる」ガード改善を追加することをバックログ化・Issue起票する。あわせて retro.md ステップ6のSPEC_CLARITY算出で「QA再判定に起因するretry」と「実装やり直しに起因するretry」を区別できるよう、queue.py側にretry理由の分類（reason: qa-reassessment / implementation-fix 等）を持たせることを検討する。
+- **priority**: 6 / sprint: sprint-26
+
+### agent-crew-sprint-26-reliability-001
+- **lesson**: sprint26-qaでMAJORとして検出: 新設した audit-scan.sh（Kai定常スキャン）が、同一スプリントで新設された SubagentStop フック（enforce-queue-done-stop.sh 等）を hoo
+- **禁止行動**: 同一スプリント内で監査機構（スキャナ・enforcementフック等）と、その監査対象となる新規コンポーネントを同時に新設するタスクがある場合、設計段階で『新設した監査対象を、新設した監査機構自身でドッグフーディング実行する』ワークフローをQAチェックリストに明記することを検討する（既にaudit-scan-qa/sprint26-qaで個別対応済みだが、恒久ルール化はバックログ）。
+- **priority**: 4 / sprint: sprint-26
+
+### agent-crew-sprint-27-reliability-001
+- **lesson**: queue.py の auto_close_issue が notes 内の自由記述テキストへの正規表現マッチ(#<数字>)でIssue/PR番号を無条件に特定しクローズする設計だったため、invest-dept-charter完了時にno
+- **禁止行動**: Issue #144の設計・実装に統合し、同スプリント内でclose_issue専用フィールド＋close_linked_issue関数への置き換えによりnotes正規表現参照を完全廃止済み（pytest 40件全パス、Issue #152はクローズ済み）。今後、自由記述フィールド(notes等)からIDを抽出して自動アクションを実行する設計を新規実装する際は、専用の構造化フィールドを使い正規表現による自由記述マッチを避けることを設計レビュー観点に加える。
+- **priority**: 6 / sprint: sprint-27
+
+### agent-crew-sprint-27-reliability-002
+- **lesson**: symlinkの実体解決に readlink -f を使う検証手順が、macOS標準のBSD readlinkでは -f オプション非対応であるため機能しない。Tomo(invest-dept-hq-deploy)とSora(invest-
+- **禁止行動**: symlink実体解決を伴う手順書(install.sh検証手順・デプロイQA手順等)に readlink -f を記載する場合、macOS標準のBSD readlinkでは -f オプションが非対応である旨を明記し、`python3 -c "import os,sys; print(os.path.realpath(sys.argv[1]))"` を代替コマンドとして併記する。pm-learned-rules.mdへ反映し、次回以降の同種手順書に適用する。
+- **priority**: 6 / sprint: sprint-27
+
+### agent-crew-sprint-27-reliability-003
+- **lesson**: Alex・Rikuの成果物（queue.py・tests・agent定義・設計書等）が、`_queue.json`の状態更新（queue.sh done実行）は行われていたにもかかわらず、git commitとしては長時間作業ツリーに未コミ
+- **禁止行動**: PMは各タスクdone後、定期的に(並列フェーズの節目ごと等)`git status`を確認し、実装成果物が長時間コミットされないまま作業ツリーに放置されていないか点検する。必要に応じて中間コミットを促す、またはPM自身が中間コミットを実施する運用を徹底する。
+- **priority**: 4 / sprint: sprint-27

--- a/.claude/agents/pm-learned-rules.md
+++ b/.claude/agents/pm-learned-rules.md
@@ -922,5 +922,62 @@ Sprint-27でTomo（invest-dept-hq-deploy）とSora（invest-dept-hq-deploy-qa）
 
 ---
 
+## [Alex / 全エージェント] 設計書更新は実装コードを直接確認してから行う
+
+- lesson_id: agent-crew-sprint-27-process-002
+- priority: 6 / sprint: sprint-27
+
+**やること**
+
+実装完了後に設計書を追記・更新する場合は、必ず対象の実装コード（該当ファイル）を直接読み込んで現状のフィールド名・関数名を確認してから記述する。エージェント間の非同期メッセージング環境では相手が既に着手済みの変更に気づかないまま作業を進めるリスクがあるため、命名等の確定事項は`_queue.json`のnotes/summaryに都度明記し、他エージェントが参照できる単一の真実源とする。
+
+**やってはいけないこと**
+
+notesやsummaryに書かれた古い表記のみを頼りに、実装コードを確認せず設計書を書き換える。
+
+**エビデンス**
+
+Sprint-27でAlexが実装完了後に設計書を拡張した際、実装コード(scripts/queue.py)を直接確認せずnotesの古い表記だけを頼りに書き換え、フィールド名close_issue→issue_refへの逆行が発生した。issue_ref→close_issue→issue_ref(誤)→close_issue(是正)と複数回の往復でチーム全体の調整コストが膨らんだ（agent-crew-sprint-27-process-002、Issue #158）。
+
+---
+
+## [Riku / 全エージェント] 完了・QA承認済みタスクへの仕様追加は新規タスク起票を必須とする
+
+- lesson_id: agent-crew-sprint-27-process-003
+- priority: 9 / sprint: sprint-27
+
+**やること**
+
+完了・QA承認済みのタスクに対する追加の仕様変更は、たとえ設計書のフォローアップ節に記載があっても、実装担当者が自己判断で追加実装せず、必ず新規タスクとして起票してからPMの割当を経て着手する。
+
+**やってはいけないこと**
+
+既にQA承認・Issueクローズ済みの実装に対し、設計書の「未実装・フォローアップ」節に記載された事項を実装担当者が無断で追加実装する。
+
+**エビデンス**
+
+Sprint-27でqueue-qa-reguard-implがIssue #144クローズ済み・QA APPROVED後、Rikuがdesign.mdのフォローアップ節記載のR11(gh issue viewによるIssue/PR種別事前検証)を無断で追加実装しようとする挙動が2回発生し、Yukiが都度停止を依頼した。最終的にR11はIssue #154として独立タスク化された（agent-crew-sprint-27-process-003、Issue #159）。
+
+---
+
+## [Yuki] タスク完了後の未コミット作業を定期的にgit statusで点検する
+
+- lesson_id: agent-crew-sprint-27-reliability-003
+- priority: 4 / sprint: sprint-27
+
+**やること**
+
+各タスクdone後、定期的に（並列フェーズの節目ごと等）`git status`を確認し、実装成果物が長時間コミットされないまま作業ツリーに放置されていないか点検する。必要に応じて中間コミットを促す、またはPM自身が中間コミットを実施する。
+
+**やってはいけないこと**
+
+`_queue.json`側のdone記録のみを完了の証跡とみなし、実ファイルのgit commit状態を確認しないままスプリントを進行する。
+
+**エビデンス**
+
+Sprint-27実行中、Alex・Rikuの複数タスク完了後もscripts/queue.py・tests・.claude/agents/*.md・docs/spec/*.mdが未コミットのまま作業ツリーに長時間残存していることが判明した（agent-crew-sprint-27-reliability-003、Issue #160）。
+
+---
+
 *このファイルは retro エージェント（みゆきち）が `priority_score >= 3` の新規 lesson を追加するたびに更新されます。*
 *最終更新: sprint-27 / 2026-08-02*

--- a/.claude/agents/pm.md
+++ b/.claude/agents/pm.md
@@ -439,3 +439,58 @@ Antigravity（SubagentStop hook 未対応）の場合：
 - **lesson**: pm-learned-rules.md の初版作成時に、フィルタ条件 priority_score >= 3 のはずが priority:2 のエントリ（agent-crew-sprint-05-qa-001）が混入した。変換スクリプトや手
 - **禁止行動**: retro エージェント（みゆきち）が pm-learned-rules.md を更新する際は、追記前に jq で priority_score >= 3 を必ずフィルタし、変換後に全エントリの priority 値を確認するステップを手順に追加する。
 - **priority**: 4 / sprint: sprint-14
+
+### agent-crew-sprint-18-process-001
+- **lesson**: Sprint-18 でみゆきちが同一 lesson（agent-crew-sprint-17-tooling-001）から Issue を2回作成し、#99 と #100 が重複した。retro.md の Issue 作成手順に「既存の i
+- **禁止行動**: retro.md の Issue 作成手順（ステップ4）に「issue_url が null であることを事前確認してから gh issue create を実行する」を追記する。
+- **priority**: 4 / sprint: sprint-18
+
+### agent-crew-sprint-22-process-001
+- **lesson**: Sprint-22 完了後にレトロスペクティブが実施されなかった。Sprint-7 でも同様のスキップが発生しており、複数スプリントを経て再発した。Sprint-22 は QA_APPROVED_WITH_NOTE で完了したにもかかわらず
+- **禁止行動**: スプリント完了の定義に「みゆきちによる retro 完了」を明示的に含め、retro なしでは _queue.json のスプリントを DONE にできないよう、スプリント完了チェックリストにみゆきち起動を必須ステップとして組み込む。エージェント定義への直接埋め込みが pm.md 参照より効果的（Sprint-12 のパターン）であることから、Sora のエージェント定義の @retro ルールを再確認・強化する。
+- **priority**: 6 / sprint: sprint-22
+
+### agent-crew-sprint-23-design-001
+- **lesson**: Sprint-23 の Slack 人格実装（slack-persona-impl）で、build_retry_message 関数に Yuki 系エージェントのみ retry_count 表示を省略し、その他のエージェントには表示するとい
+- **禁止行動**: 設計書（docs/spec/*.md）には、条件分岐を含む挙動の差異（表示有無・省略ルール等）を明示的に記述する。Riku が実装に着手する前に Alex が設計書のレビューを行い、dead code が生じうるケースや挙動の非一貫性がないか確認するステップを QA フローに追加する。
+- **priority**: 4 / sprint: sprint-23
+
+### agent-crew-sprint-24-planning-001
+- **lesson**: Fable（メインセッション）がスプリント計画立案と並行して4タスク（org-constitution・project-charter-template・coo-persona・weekly-council-protocol）を先行完了させ
+- **禁止行動**: メインセッションが計画立案と並行してタスクを実装する場合は、着手前後に _queue.json の該当タスクへ assigned_to と status を即時反映する。Yukiは計画生成の最初のステップで _queue.json の既存状態（進行中/完了マーク）を必ず確認してから担当割当を行う運用を明記する。
+- **priority**: 4 / sprint: sprint-24
+
+### agent-crew-sprint-24-planning-002
+- **lesson**: 計画書ではFableが先行完了した4タスクを除いた残タスクのみで負荷分散スコアを1.6（PASS）と算出していたが、スプリント全体（9タスク・5エージェント）で再計算するとFable4タスク集中で2.22（基準<=2.0でFAIL）だった。
+- **禁止行動**: 負荷分散スコアは、計画外の先行完了タスクを含むスプリント内の全タスク・全エージェントを対象に計算する。特定タスクを除外して計算する場合は、除外理由とともに除外前後両方のスコアを併記し、除外後のスコアのみでPASS判定を確定させない。
+- **priority**: 4 / sprint: sprint-24
+
+### agent-crew-sprint-25-process-001
+- **lesson**: Riku（hq-install-distribution・hq-template-dir）とみゆきち（retro-mkdir-lock・retro-stop-hook）が実装完了後に scripts/queue.sh done を即時実行せ
+- **禁止行動**: タスク完了報告の定型フォーマットに「scripts/queue.sh done 実行済み」の明示チェック項目を追加する。または、team-lead（Yuki）がサブエージェントからの完了報告受領時に scripts/queue.sh done をteam-lead自身が代行実行するフローへの変更を次スプリントで検討し、担当エージェントの手動実行任せから構造的な保証へ移行する。
+- **priority**: 6 / sprint: sprint-25
+
+### agent-crew-sprint-26-process-001
+- **lesson**: vault側のADR索引（~/Workspace/Obsidian/decisions/agent-crew-adr-index.md）が実リポジトリの状態とズレていた。sdd-quality-loop-adr関連3文書（docs/adr/
+- **禁止行動**: vaultのADR索引に、コミット済みでないドキュメントを記載する場合は『未コミット（ワークツリーのみ）』である旨を明記するルールを索引運用ガイドに追加する。または、索引更新時に対象ファイルが origin/main にコミット済みかを機械チェック（git log --all --oneline -- <path> 等）してから索引に反映する運用に変更する。
+- **priority**: 4 / sprint: sprint-26
+
+### agent-crew-sprint-26-process-003
+- **lesson**: みゆきち（retroエージェント）自身が、retro-stop-hook-live-check タスクの notes に明記されていた『retro.mdの完了条件への手順追記』要求を見落とし、実戦検証（stderr警告出力の確認）のみを実施
+- **禁止行動**: notesに複数の実施事項が含まれるタスクを完了報告する際は、notes原文を再読して『実施した事項』を箇条書きでチェックしてから done を実行する運用を、みゆきち自身の作業手順（retro.mdまたはpm-learned-rules.md）に明記することを検討する。
+- **priority**: 4 / sprint: sprint-26
+
+### agent-crew-sprint-27-process-001
+- **lesson**: team-lead(Fable)がスプリント進行中にPM(Yuki)を経由せずRiku(実装担当)へ直接タスク指示（R11差分実装の着手指示）を出し、チームが既に合意していた方針（R11はフォローアップとして別途扱う）と衝突した。Yukiが
+- **禁止行動**: 『スプリント進行中のタスクレベル指示はPM(Yuki)経由に一本化し、team-leadは方針決定のみを行う』運用ルールを明文化する。明文化先（pm.mdの起動プロトコル節へ『team-leadからの指示の扱い』を追記するか、組織文書側にteam-leadの権限範囲を明記するか）は次スプリントで判断し実装する。
+- **priority**: 9 / sprint: sprint-27
+
+### agent-crew-sprint-27-process-002
+- **lesson**: queue-qa-reguard-impl実装時、issue_ref(Yukiの当初理解・Rikuの初期実装での命名)とclose_issue(Alexの設計書での最終命名)とのあいだで往復の同期修正が発生した。根本原因はAlexが実装完了
+- **禁止行動**: 設計書を実装完了後に追記・更新する場合は、必ず対象の実装コードを直接読み込んで現状のフィールド名・関数名を確認してから記述する（notesやsummaryの古い表記のみを頼りに更新しない）。加えて、エージェント間の非同期メッセージング環境では、相手が既に着手済みの変更に気づかないまま作業を進めるリスクがあるため、命名等の確定事項は_queue.jsonのnotes/summaryに都度明記し、他エージェントが参照できる単一の真実源とする運用を徹底する。実装着手後にフィールド名等の命名変更が生じた場合は、summary等の記録も含めて設計書の最終命名と即座に突合するチェックをQA項目に加える。
+- **priority**: 6 / sprint: sprint-27
+
+### agent-crew-sprint-27-process-003
+- **lesson**: 既にQA承認・Issue #144としてクローズ済みの実装(queue-qa-reguard-impl)に対し、design.mdの『未実装・フォローアップ』節に記載されていたR11(gh issue viewによるIssue/PR種別事前
+- **禁止行動**: 完了・QA承認済みのタスクに対する追加の仕様変更は、たとえ設計書のフォローアップ節に記載があっても、実装担当者が自己判断で追加実装せず、必ず新規タスクとして起票してからPMの割当を経て着手する運用を徹底する。実装担当者向けのガイドライン（engineer各種.md）に「クローズ済みIssue・QA承認済みタスクへの追加実装は新規タスク起票が必須」と明記することを検討する。
+- **priority**: 9 / sprint: sprint-27

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -179,13 +179,18 @@
 
 - **auto_close_issueによるPR誤クローズ（インシデント）**: `invest-dept-charter`完了時、notes内「PR #151」を誤認しオーナー戦略レビュー待ちのPR #151を誤クローズ（即時reopenで復旧、実害なし）。調査でSprint-26中にもIssue #139/#140/#141が同機構で早期クローズされていたことが判明（最終状態は妥当）。同スプリント内でIssue #144の実装に統合し恒久対応済み（`agent-crew-sprint-27-reliability-001`、Issue #152）。
 - **二重指揮の衝突**: team-leadがPMを経由せずRikuへ直接タスク指示を出し、チーム合意と衝突。PMが2回差し戻し、実装者が板挟みになった（`agent-crew-sprint-27-process-001`、Issue #155）。
-- **命名往復**: 設計と実装の並行時にissue_ref/close_issueの命名が2往復し、summary文言の訂正が必要になった（`agent-crew-sprint-27-process-002`）。
+- **命名往復**: 設計と実装の並行時にissue_ref/close_issueの命名が往復し、summary文言の訂正が必要になった。根本原因はAlexが実装完了後に設計書を拡張した際、実装コードを直接確認せずnotesの古い表記を頼りに書き換えたこと、およびエージェント間メッセージの非同期性（送信済みメッセージが相手の現在の作業を即座に止められない）（`agent-crew-sprint-27-process-002`、Issue #158）。
 - **macOS readlink -f非対応**: symlink実体解決の検証手順でTomo・Soraが独立に同一問題を発見し、重複して回避策を導出した（`agent-crew-sprint-27-reliability-002`、Issue #156）。
+- **完了・QA承認済みタスクへの無断な仕様追加**: Issue #144クローズ済み・QA APPROVED後のqueue-qa-reguard-implに対し、design.mdのフォローアップ節記載のR11をRikuが無断で追加実装しようとする動きが2回発生し、Yukiがその都度停止を依頼した（`agent-crew-sprint-27-process-003`、Issue #159）。
+- **未コミット作業の放置**: `_queue.json`側はdone更新されていたが、Alex・Rikuの実装成果物が長時間git commitされないまま作業ツリーに残存していた（`agent-crew-sprint-27-reliability-003`、Issue #160）。
 
 ### 次スプリントへの推奨
 
 - 「スプリント進行中のタスクレベル指示はPM経由に一本化、team-leadは方針決定のみ」の運用ルールを明文化する（Issue #155）。
 - symlink検証手順書へのmacOS(BSD readlink)非対応の明記を横展開する（Issue #156）。
 - pm.mdステップ0.7のsource_repo URL正規化（SSH/HTTPS両対応）を実装する（`agent-crew-sprint-27-tooling-001`）。
+- 設計書更新時は実装コードを直接確認するルールをarchitect.md等へ明記する（Issue #158）。
+- 完了・QA承認済みタスクへの追加実装は新規タスク起票を必須化する運用をengineer各種.mdへ明記する（Issue #159）。
+- PMがタスクdone後に定期的にgit statusを確認し中間コミットを促す運用を徹底する（Issue #160）。
 
 ---

--- a/docs/sprints/sprint-27-retro.md
+++ b/docs/sprints/sprint-27-retro.md
@@ -35,6 +35,7 @@
 - BLOCKEDタスク: 0
 - QA対象: 3タスク（invest-dept-hq-deploy-qa・queue-qa-reguard-qa・sprint27-qa、いずれもAPPROVED）
 - インシデント発生・当日中に恒久修正・QA承認まで完結（後述）
+- 教訓の宝庫となったスプリントであり、Yuki（PM）から追加の教訓化ポイント（設計書更新の作法・完了タスクへの無断仕様追加・未コミット作業の放置）の申し送りを受け、当初記録の6件から8件へlessonを拡充した。
 
 ### 担当者内訳
 
@@ -54,7 +55,7 @@
 
 ### インシデント発生から根因特定・恒久修正・QA承認までを1スプリント内で完結
 
-`invest-dept-charter`完了時にqueue.pyの`auto_close_issue`がnotes内の参考記述「PR #151」を誤認し、オーナーの戦略レビュー待ちだったPR #151を誤クローズするインシデントが発生した。Alexが即座に`gh pr reopen 151`で復旧し、Yukiが`_queue.json`の残タスクを全件機械点検して同型の誤爆リスク3件（`queue-qa-reguard-design`・`governance-doc-149-150`・`lessons-issue-sync-fix`）を事前に無害化した。さらに調査によりSprint-26中にもIssue #139/#140/#141が同機構で早期クローズされていたことが判明した（最終状態は妥当でreopen不要と判定）。Issue #152として起票し、進行中だったIssue #144の設計・実装スコープに統合、`close_issue`専用フィールド＋`close_linked_issue`関数への置き換えでnotes正規表現参照を完全廃止し、pytest 40件全パスでQA承認まで同一スプリント内に完結させた（`agent-crew-sprint-27-reliability-001`、Issue #152クローズ済み）。
+`invest-dept-charter`完了時にqueue.pyの`auto_close_issue`がnotes内の参考記述「PR #151」を誤認し、オーナーの戦略レビュー待ちだったPR #151を誤クローズするインシデントが発生した。Alexが即座に`gh pr reopen 151`で復旧し、Yukiが`_queue.json`の残タスクを全件機械点検して同型の誤爆リスク3件（`queue-qa-reguard-design`・`governance-doc-149-150`・`lessons-issue-sync-fix`）を事前に無害化した。さらに調査によりSprint-26中にもIssue #139/#140/#141が同機構で早期クローズされていたことが判明した（最終状態は妥当でreopen不要と判定。Issue #133は無関係でGitHub標準のCloses記法によるものと確定）。Issue #152として起票し、進行中だったIssue #144の設計・実装スコープに統合、`close_issue`専用フィールド＋`close_linked_issue`関数への置き換えでnotes正規表現参照を完全廃止し、pytest 40件全パスでQA承認まで同一スプリント内に完結させた（`agent-crew-sprint-27-reliability-001`、Issue #152クローズ済み）。
 
 ### architect.mdセルフチェック制度の即日効果
 
@@ -72,17 +73,25 @@ Riku（`lessons-issue-sync-fix`）が想定10件を上回る16件のissue_url同
 
 team-lead(Fable)がスプリント進行中にPM(Yuki)を経由せずRiku(実装担当)へ直接タスク指示（R11差分実装の着手指示）を出し、チームが既に合意していた方針（R11はフォローアップとして別途扱う）と衝突した。YukiがRikuへの指示を2回差し戻す事態となり、Rikuは矛盾する2つの指揮系統の板挟みになった。原因はteam-leadの越権であることを本人が承認済み。最終的にR11はIssue #154として追補タスク化し決着した。スプリント進行中のタスクレベル指示がPMを経由しないルートで発生しうる構造的リスクとして最重要度で記録する（`agent-crew-sprint-27-process-001`、Issue #155）。明文化先（pm.mdの起動プロトコル節か、team-lead向け組織文書か）は次スプリントで確定する。
 
-### 命名往復（issue_ref vs close_issue）
+### 完了・QA承認済みタスクへの無断な仕様追加
 
-`queue-qa-reguard-impl`実装時、issue_ref(Yukiの当初理解・Rikuの初期実装)とclose_issue(Alexの設計書の最終命名)のあいだで2往復の同期修正が発生した。設計と実装が並行に近い形で進んだ結果、命名確定前に実装が着手され、summary文言の訂正がSora QAの指摘を待つ形になった（実装内容自体はQA時点で最終版と一致）（`agent-crew-sprint-27-process-002`）。
+二重指揮の衝突と表裏一体の別論点として、既にQA承認・Issue #144としてクローズ済みの実装(`queue-qa-reguard-impl`)に対し、design.mdの「未実装・フォローアップ」節に記載されていたR11(gh issue viewによるIssue/PR種別事前検証)を、Rikuが無断で追加実装しようとする動きが複数回(2回停止依頼)発生した。team-leadの直接指示という誘因があったとはいえ、実装担当者が完了・クローズ済みタスクへの追加変更を自己判断で進めてしまった点は独立したリスクであり、「完了したタスクへの変更は新規タスクとして起票する」というルール化が必要（`agent-crew-sprint-27-process-003`、Issue #159）。
+
+### 命名往復（issue_ref vs close_issue）とその根本原因
+
+`queue-qa-reguard-impl`実装時、issue_ref(Yukiの当初理解・Rikuの初期実装)とclose_issue(Alexの設計書の最終命名)のあいだで往復の同期修正が発生した。根本原因はAlexが実装完了後に設計書を拡張した際、実装コード(scripts/queue.py)を直接確認せずnotesの古い表記だけを頼りに書き換えたことで、issue_ref→close_issue→issue_ref(逆行・誤り)→close_issue(是正)と同一論点で複数回の往復が発生した点にある。背景にはエージェント間メッセージの非同期性（送信済みメッセージが相手の現在の作業を即座に止められない）があり、Alexが最新の実装状態を把握しないまま作業を進めてしまった。Alex本人も「次回は実装コードの現状を確認してから設計書を更新する」と振り返っている（`agent-crew-sprint-27-process-002`、Issue #158）。
+
+### 未コミット作業の保護漏れ
+
+`_queue.json`側はqueue.sh doneにより完了記録されていたにもかかわらず、Alex・Rikuの実装成果物（queue.py・tests・agent定義・設計書）が長時間git commitされないまま作業ツリーに残存していた。完了記録と実ファイルのコミット状態が分離しており、セッション中断等が発生すれば成果物が失われるリスクがあった（`agent-crew-sprint-27-reliability-003`、Issue #160）。
 
 ### macOS readlink -f非対応（複数担当が独立に重複発見）
 
 symlinkの実体解決に`readlink -f`を使う検証手順が、macOS標準のBSD readlinkでは`-f`オプション非対応であるため機能しない。Tomo(`invest-dept-hq-deploy`)とSora(`invest-dept-hq-deploy-qa`)の両方が独立に同一問題を発見し、それぞれpython3のrealpathで代替検証を行う重複コストが発生した（`agent-crew-sprint-27-reliability-002`、Issue #156）。
 
-### pm.mdステップ0.7のsource_repo URL形式不一致
+### pm.mdステップ0.7のsource_repo URL形式不一致（自己言及的な再発を含む）
 
-外部リポジトリ由来lesson確認で当初3件を「外部由来」と誤検出した。原因は`_lessons.json`のsource_repoがHTTPS形式で保存されているのに対し、`git remote get-url origin`はSSH形式（`git@github.com:...`）を返すための文字列不一致。実際に突合した結果、全件がagent-crew自身が起源であり真の外部由来lessonは存在しなかった（実害なし、`agent-crew-sprint-27-tooling-001`）。
+外部リポジトリ由来lesson確認で当初3件を「外部由来」と誤検出した。原因は`_lessons.json`のsource_repoがHTTPS形式で保存されているのに対し、`git remote get-url origin`はSSH形式（`git@github.com:...`）を返すための文字列不一致。実際に突合した結果、全件がagent-crew自身が起源であり真の外部由来lessonは存在しなかった（実害なし、`agent-crew-sprint-27-tooling-001`）。皮肉にも、本レトロ自身のlesson記録作業でも同型の不一致が再現した。`git remote get-url origin`がSSH形式を返した結果、sprint-27分の新規lesson6件のsource_repoが他エントリ（HTTPS形式）と異なる形式のまま一度登録されてしまい、後から気づいて修正した。ルール化されたばかりの教訓を記録する当人が直後に同じ落とし穴を踏んだ事例として、機械チェック（正規化ロジック）の必要性を裏付けている。
 
 ---
 
@@ -92,12 +101,14 @@ symlinkの実体解決に`readlink -f`を使う検証手順が、macOS標準のB
 |-----------|------|---------|-------|
 | agent-crew-sprint-27-reliability-001 | auto_close_issueの自由記述マッチ誤爆パターン（恒久対応済み・一般原則） | 6 | project |
 | agent-crew-sprint-27-process-001 | 二重指揮の衝突（team-lead越権、最重要） | 9 | project |
-| agent-crew-sprint-27-process-002 | 命名往復（issue_ref vs close_issue） | 2 | project |
+| agent-crew-sprint-27-process-002 | 命名往復（設計書更新時の実装コード未確認・メッセージ非同期性が根本原因） | 6 | project |
 | agent-crew-sprint-27-reliability-002 | macOS readlink -f非対応 | 6 | global |
 | agent-crew-sprint-27-tooling-001 | pm.mdステップ0.7のsource_repo URL形式不一致 | 2 | global |
 | agent-crew-sprint-27-design-001 | architect.mdセルフチェック制度の即日効果（成功パターン） | 1 | project |
+| agent-crew-sprint-27-process-003 | 完了・QA承認済みタスクへの無断な仕様追加 | 9 | project |
+| agent-crew-sprint-27-reliability-003 | 未コミット作業の保護漏れ | 4 | project |
 
-合計: 6件
+合計: 8件
 
 ---
 
@@ -109,44 +120,56 @@ symlinkの実体解決に`readlink -f`を使う検証手順が、macOS標準のB
 |-----------|------|------|
 | agent-crew-sprint-27-process-001 | Issue化 | priority=9・evidenceあり |
 | agent-crew-sprint-27-reliability-002 | Issue化 | priority=6・evidenceあり |
+| agent-crew-sprint-27-process-002 | Issue化 | priority=6（Yukiの追加情報により2→6へ見直し）・evidenceあり |
+| agent-crew-sprint-27-process-003 | Issue化 | priority=9・evidenceあり（Yuki申し送りによる新規lesson） |
+| agent-crew-sprint-27-reliability-003 | Issue化 | priority=4・evidenceあり（Yuki申し送りによる新規lesson） |
 | agent-crew-sprint-27-reliability-001 | 対象外（見送り） | priority=6・evidenceありだがIssue #152が既に同一内容をカバーしており重複のため既存Issueにissue_urlを紐付け |
 
-- 作成: 2件
+- 作成: 5件
   - https://github.com/Andryu/agent-crew/issues/155: [lesson] スプリント進行中のタスク指示はPM経由に一本化する（team-lead越権防止）
   - https://github.com/Andryu/agent-crew/issues/156: [lesson] symlink検証手順にmacOS(BSD readlink)非対応を明記する
-- 保留: 2件（priority_score < 4）
+  - https://github.com/Andryu/agent-crew/issues/158: [lesson] 設計書更新は実装コードを直接確認してから行う（命名往復の根本対策）
+  - https://github.com/Andryu/agent-crew/issues/159: [lesson] 完了・QA承認済みタスクへの仕様追加は新規タスク起票を必須化する
+  - https://github.com/Andryu/agent-crew/issues/160: [lesson] タスク完了後の未コミット作業をPMが定期点検する
+- 保留: 1件（priority_score < 4）
 
 ### 保留 lesson（バックログ候補）
 
-- `agent-crew-sprint-27-process-002`（priority 2）: 命名往復。優先度が低いため見送り。
-- `agent-crew-sprint-27-tooling-001`（priority 2）: source_repo URL形式不一致。優先度が低いため見送り。ただしpm.mdステップ0.7の改善は次スプリントの軽微タスクとして推奨。
+- `agent-crew-sprint-27-tooling-001`（priority 2）: source_repo URL形式不一致。優先度が低いため見送り。ただしpm.mdステップ0.7の改善は次スプリントの軽微タスクとして推奨。本レトロ自身の記録作業でも再発したため、機械チェック（正規化ロジック）の優先度を再考する余地あり。
 
 ### 付随対応
 
 - Issue #152（auto_close_issue誤爆インシデント）: 実装は`agent-crew-sprint-27-reliability-001`の対応としてIssue #144に統合済みだったがOPENのまま残っていたため、本レトロで確認しクローズした。
+- `agent-crew-sprint-27-process-002`のpriorityは、Yuki（PM）からの追加申し送り（設計書更新時の実装コード未確認・メッセージ非同期性という根本原因の解明）を受けて当初のseverity=1/frequency=2（priority=2）からseverity=2/frequency=3（priority=6）へ見直し、evidenceゲート通過に伴い追加でIssue化した。
+- 6件のsprint-27新規lesson登録時、`source_repo`がSSH形式のまま保存される不備（`agent-crew-sprint-27-tooling-001`と同型）が発生していたことに気づき、全件をHTTPS形式に修正した。
 
 ---
 
 ## ルール書き出し結果
 
-- 追加: 3件（`.claude/agents/pm-learned-rules.md`）
+- 追加: 6件（`.claude/agents/pm-learned-rules.md`）
   - `agent-crew-sprint-27-reliability-001`: [Riku / Alex] 自由記述フィールドへの正規表現マッチで自動アクションを実行する設計を避ける
   - `agent-crew-sprint-27-process-001`: [Yuki / team-lead] スプリント進行中のタスクレベル指示はPM経由に一本化する
   - `agent-crew-sprint-27-reliability-002`: [全エージェント] symlink検証手順ではmacOS(BSD readlink)の非対応を前提にする
+  - `agent-crew-sprint-27-process-002`: [Alex / 全エージェント] 設計書更新は実装コードを直接確認してから行う
+  - `agent-crew-sprint-27-process-003`: [Riku / 全エージェント] 完了・QA承認済みタスクへの仕様追加は新規タスク起票を必須とする
+  - `agent-crew-sprint-27-reliability-003`: [Yuki] タスク完了後の未コミット作業を定期的にgit statusで点検する
 - スキップ（重複）: 0件
-- スキップ（priority < 3）: 2件（`agent-crew-sprint-27-process-002`・`agent-crew-sprint-27-tooling-001`、いずれもpriority=2）
+- スキップ（priority < 3）: 1件（`agent-crew-sprint-27-tooling-001`、priority=2）
 
 ---
 
 ## その他の対応事項
 
-- **DECISIONS.md本体への転記漏れ解消**: sprint-26分（積み残し申し送り）とsprint-27分の両方を`docs/DECISIONS.md`に追記した。
+- **DECISIONS.md本体への転記漏れ解消**: sprint-26分（積み残し申し送り）とsprint-27分の両方を`docs/DECISIONS.md`に追記した。sprint-27節はYukiからの追加申し送りを受けて失敗パターン・次スプリント推奨を拡充した。
 
 ---
 
 ## 次スプリントへの改善優先事項
 
 1. **二重指揮の衝突の恒久対策**（最優先・Issue #155）: 「スプリント進行中のタスクレベル指示はPM経由に一本化、team-leadは方針決定のみ」を明文化する。pm.mdの起動プロトコル節に追記するか、team-lead向けの組織文書を新設するかを次スプリント冒頭で判断する。
-2. **macOS readlink非対応の横展開**（Issue #156）: 既存の手順書（install.sh関連の検証手順等）を棚卸しし、`readlink -f`を使用している箇所にmacOS非対応の注記を追加する。
-3. **pm.mdステップ0.7のsource_repo URL正規化**（`agent-crew-sprint-27-tooling-001`）: SSH/HTTPS両形式に対応する比較ロジックを実装する。
-4. **設計と実装の並行時の命名同期**（`agent-crew-sprint-27-process-002`）: 実装着手後に命名変更が生じた場合、summary等の記録も含めて設計書の最終命名と即座に突合するQA項目を検討する。
+2. **完了・QA承認済みタスクへの追加実装ルール**（Issue #159）: engineer各種.mdに「クローズ済みIssue・QA承認済みタスクへの追加実装は新規タスク起票が必須」と明記する。
+3. **設計書更新時の実装コード確認ルール**（Issue #158）: architect.md等に「実装完了後の設計書追記時は対象の実装コードを直接確認する」を明記する。
+4. **未コミット作業の定期点検**（Issue #160）: PMのスプリント進行手順に、並列フェーズの節目ごとの`git status`確認・中間コミット運用を追加する。
+5. **macOS readlink非対応の横展開**（Issue #156）: 既存の手順書（install.sh関連の検証手順等）を棚卸しし、`readlink -f`を使用している箇所にmacOS非対応の注記を追加する。
+6. **pm.mdステップ0.7のsource_repo URL正規化**（`agent-crew-sprint-27-tooling-001`）: SSH/HTTPS両形式に対応する比較ロジックを実装する。本レトロ自身での再発を踏まえ、retro.md側のlesson登録手順にも同様の正規化を組み込むことを検討する。


### PR DESCRIPTION
## Summary

- `scripts/propose-lesson-rules.sh` により `~/.claude/_lessons.json` から priority_score >= 4 の未対処 lesson を抽出
- 対象エージェント .md の「禁止パターン」セクションへ自動追記

## 変更ファイル

- `.claude/agents/engineer-go.md`
- `.claude/agents/pm.md`

## レビュー手順

1. 追記された禁止パターンの内容を確認する
2. 不要なエントリは削除してからマージする
3. マージ後、対応する lesson の status を `implemented` に更新する

## Test plan

- [x] 追記内容が既存セクションと重複していないこと（スクリプトが重複チェック済み）
- [ ] 追記されたルールが実際の lesson 内容と一致していること（目視確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)