### PR TITLE
feat(dashboard): GitHub Pages に /dashboard/ を追加（巡室と合成デプロイ）

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,0 +1,70 @@
+name: Deploy GitHub Pages (loop-room + dashboard)
+
+# Pages のデプロイはサイト全体を置換するため、コンテンツ源が複数ブランチに
+# またがる場合は必ず「全ソースを合成した1つのアーティファクト」を作る。
+# この workflow は main と research/game-department-prototype の両方に同一内容で
+# 置き、どちらのブランチへの push でも合成サイト全体を再デプロイする。
+#
+# サイト構成:
+#   /                → ゲーム「巡室」(research/game-department-prototype の game-prototype/loop-room)
+#   /dashboard/      → STONEFISH ダッシュボード実データ版 (main の dashboard/app/index.html)
+#   /dashboard/demo.html → シミュレーションデモ (main の dashboard/prototype/)
+
+on:
+  push:
+    branches:
+      - main
+      - research/game-department-prototype
+    paths:
+      - "dashboard/**"
+      - "game-prototype/loop-room/**"
+      - ".github/workflows/deploy-pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      # トリガー元ブランチに依らず、常に両ソースを明示的にチェックアウトする
+      - name: Checkout main (dashboard)
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          path: src-main
+
+      - name: Checkout game branch (loop-room)
+        uses: actions/checkout@v4
+        with:
+          ref: research/game-department-prototype
+          path: src-game
+
+      - name: Build combined site
+        run: |
+          mkdir -p _site/dashboard
+          cp -r src-game/game-prototype/loop-room/. _site/
+          cp src-main/dashboard/app/index.html _site/dashboard/index.html
+          cp src-main/dashboard/prototype/stonefish-dashboard.html _site/dashboard/demo.html
+
+      - name: Configure Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/dashboard/app/index.html
+++ b/dashboard/app/index.html
@@ -1164,6 +1164,14 @@ fitSpace();
 renderAll();
 setInterval(uiTick, 1800);
 connectWs();
+// GitHub Pages（https）で閲覧時: ローカルサーバが無い訪問者向けにデモへの導線を出す
+if (location.protocol === 'https:'){
+  const cs = document.getElementById('connStatus');
+  const a = document.createElement('a');
+  a.href = 'demo.html'; a.textContent = 'DEMO';
+  a.className = 'conn-status'; a.style.textDecoration = 'underline'; a.title = 'シミュレーションデモを見る';
+  cs.after(a);
+}
 requestAnimationFrame(drawSpace);
 requestAnimationFrame(drawOffice);
 })();


### PR DESCRIPTION
## 概要

STONEFISH ダッシュボードを GitHub Pages でも表示できるようにする。

既存の Pages サイトはゲーム「巡室」（`research/game-department-prototype` の workflow）がルートにデプロイしており、Pages のデプロイは**サイト全体を置換する**ため、単純に workflow を追加すると相互上書きになる。そこで両ソースを合成する共通 workflow に統一する。

## サイト構成

| URL | 内容 | ソース |
|---|---|---|
| `/` | 巡室（現状の URL を維持） | research ブランチ `game-prototype/loop-room/` |
| `/dashboard/` | ダッシュボード実データ版 | main `dashboard/app/index.html` |
| `/dashboard/demo.html` | シミュレーションデモ | main `dashboard/prototype/` |

- `/dashboard/` はローカルサーバ（`ws://127.0.0.1:8787`）稼働中のマシンで開いたときだけ LIVE。訪問者には OFFLINE + ヘッダの DEMO 導線（https 時のみ表示）
- 実データが Pages に公開されることはない（静的 HTML のみ。イベント・トークンはローカルに留まる）

## 注意（マージ後の作業）

research ブランチ側の `deploy-loop-room.yml` も同内容の合成 workflow への置換が必要（ゲーム側の push がダッシュボードを消さないように）。マージ後に対応する。

## Test Plan

- [x] 公開対象 HTML 2ファイルに個人情報が含まれないことを grep で確認
- [x] workflow の build ステップのコピー構成を確認（ゲーム→ルート、app→/dashboard/index.html、prototype→/dashboard/demo.html）
- [ ] マージ後: Actions の実行成功と https://andryu.github.io/agent-crew/ （巡室）・ https://andryu.github.io/agent-crew/dashboard/demo.html （デモ）の表示確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaUuTfTDryzX6iBE5teCYY