### PR TITLE
feat: 学習ループに効果検証（Level 0-1）を導入

### DIFF
--- a/.claude/agents/retro.md
+++ b/.claude/agents/retro.md
@@ -51,12 +51,36 @@ model: sonnet
 #### source_repo の取得（必須）
 
 lesson を記録する前に、呼び出し元リポジトリの URL を取得して `source_repo` フィールドに設定する。
+**SSH 形式（`git@github.com:...`）は必ず HTTPS 形式へ正規化してから保存する**
+（`agent-crew-sprint-27-tooling-001` の恒久対応。`scripts/lessons.sh` 経由なら自動正規化される）：
 
 ```bash
 SOURCE_REPO=$(git remote get-url origin 2>/dev/null || echo "local")
+# SSH → HTTPS 正規化（lessons.sh add を使う場合は不要 — スクリプト側で実施される）
+SOURCE_REPO=$(echo "$SOURCE_REPO" | sed -E 's#^git@([^:]+):#https://\1/#; s#\.git$##')
 ```
 
 `source_repo` はクロスリポジトリ教訓集約（Issue #110）の基盤フィールドであり、**必ず全 lesson エントリに含める**。
+
+#### 効果検証フィールド（必須 — learning-loop-verification-proposal.md）
+
+`type: failure` かつ `priority_score >= 3`（ルール書き出し対象）の lesson には
+**`recurrence_condition`（再発検知条件）を必ず設定する**。
+「何が観測されなくなったら効いたと言えるか」を1文で書く（10文字以上）。
+例: 二重指揮の衝突 → 「PM経由でないタスク指示が発生しない」。
+条件を書けない観察はルール化に値しないため、type を observation に落とすか記録を見送る。
+
+あわせて `enforcement` を判定する:
+
+| enforcement | 判定基準 |
+|-------------|---------|
+| `code` | script/lint/hook で機械的に強制できる（→ コード化タスクを起票し、プロンプト書き出しはしない） |
+| `prompt` | エージェントの行動指針としてしか表現できない（デフォルト） |
+| `process` | 人間・運用手順の問題 |
+
+`scripts/lessons.sh add` を使えばこれらのバリデーション（recurrence_condition 必須チェック・
+source_repo 正規化・`verification_streak: 0` の初期化）が自動で適用される。手書き jq で
+記録する場合も同じフィールドを必ず含めること。
 
 #### スコープ（scope）の判断基準（必須）
 
@@ -154,6 +178,31 @@ mv "$tmp" ~/.claude/_lessons.json
 release_lock
 trap - EXIT INT TERM
 ```
+
+### ステップ 2.7: 前スプリントルールの再発チェック（効果検証・必須）
+
+今スプリントの観察記録（ステップ2）が終わったら、**過去スプリントに書き出したルールが
+効いたかどうかを再発カウントで測る**（learning-loop-verification-proposal.md L0）。
+
+1. 今スプリントで記録した failure lesson を、過去のルール書き出し対象 lesson
+   （`type: failure`, `priority_score >= 3`, status が proposed/issue_created/implemented）と
+   突合し、**同型の再発**（同じ recurrence_condition に反する事象）があるか判定する。
+2. 判定結果を渡して verify-check を実行する:
+
+```bash
+# 再発がなかった場合
+bash scripts/lessons.sh verify-check <今スプリント>
+
+# 同型再発を観察した場合（再発した過去lessonのIDを指定）
+bash scripts/lessons.sh verify-check <今スプリント> --recurred <lesson-id> [--recurred <lesson-id>]...
+```
+
+- 再発なし2スプリント連続 → 該当 lesson は `verified` に自動遷移する（ルールは効いた）
+- 再発あり → streak が 0 にリセットされ `last_recurrence_sprint` が記録される。
+  **これは「プロンプトのルールでは防げなかった」実績**なので、機械化（`enforcement: code` 化 =
+  script/lint/hook での強制）タスクの起票を Yuki への完了報告に含めること
+3. verify-check の出力（再発リセット・verified 遷移・streak 進行中の件数）は
+   ステップ7の完了報告に「効果検証結果」として添付する
 
 ### ステップ 3: エビデンスゲートの実行
 
@@ -270,12 +319,19 @@ done
 
 #### 対象教訓の抽出
 
+`enforcement: code` の lesson は **書き出し対象外**（コードで強制済みのルールを
+プロンプトにも書くと二重管理になる — learning-loop-verification-proposal.md L1-4）。
+
 ```bash
 jq '.lessons[] | select(
   (.status == "open" or .status == null) and
-  (.priority_score >= 3)
+  (.priority_score >= 3) and
+  ((.enforcement // "prompt") != "code")
 )' ~/.claude/_lessons.json
 ```
+
+`enforcement: code` と判定したが未実装の lesson は、書き出す代わりに
+コード化タスク（対象スクリプトへの実装）の起票を Yuki へ申し送る。
 
 #### 重複チェック
 
@@ -375,6 +431,16 @@ LOAD_RATIO_TASKCOUNT=$(echo "$LOAD_BALANCE" | jq '.load_balance.by_task_count.sc
 
 スコアが合格基準を下回った軸は、次スプリントの改善優先事項として lesson に記録する。
 
+#### メタ評価ルール（試験運用 — sprint-30 まで）
+
+**全4軸が PASS なのに、今スプリントで `priority_score >= 6` の lesson を2件以上記録した場合**、
+ルーブリックが測るべきものを測れていない兆候とみなし、完了報告に
+「ルーブリック改訂タスクの起票提案」を含める（sprint-27 で実際に発生したパターン:
+全軸PASSと priority 9 教訓2件の同居）。
+
+試験運用期間中は発火の有無を完了報告に毎回記録し（発火なしの場合も「メタ評価: 発火なし」と明記）、
+2スプリント分の発火頻度を見てから正式ルール化・閾値調整を判断する。
+
 ### ステップ 6.5: enforce-retro-stop.sh 実戦検証（スプリント中1回・完了条件）
 
 Issue #128 / Sprint-25レトロ「次スプリントへの改善優先事項」対応。
@@ -415,6 +481,14 @@ Stop フック（`scripts/enforce-retro-stop.sh`）が実運用の起動経路�
 | 負荷分散 | [0.xx] | <= 2.0 | [PASS / FAIL] |
 
 > FAIL 軸: [軸名]（次スプリントの改善優先事項）
+> メタ評価: [発火なし / 発火 — ルーブリック改訂タスクの起票を提案（全軸PASSかつpriority>=6が[n]件）]
+
+### 効果検証結果（ステップ2.7）
+- verify-check 実行: [今スプリント名]
+- 再発リセット: [n] 件 [→ 機械化候補: lesson-id, ...]
+- verified 遷移: [n] 件 [→ lesson-id, ...]
+- streak 進行中: [n] 件
+- 機械化タスクの起票提案: [なし / あり — 対象と実装先を記載]
 
 ### enforce-retro-stop.sh 実戦検証（ステップ6.5）
 - 発動確認（隔離環境）: [PASS / 未確認]

--- a/docs/spec/learning-loop-verification-proposal.md
+++ b/docs/spec/learning-loop-verification-proposal.md
@@ -1,0 +1,140 @@
+# 学習ループへの効果検証の導入 — 段階的導入提案（v2）
+
+作成日: 2026-08-08
+ステータス: Draft（オーナー承認待ち）
+起案: team-lead（Fable）
+レビュー: Sora（QA） — 条件付き承認（2026-08-08、指摘10件を本版に反映済み）
+関連: docs/spec/lessons-json-schema.md / docs/spec/evidence-gate-design.md / docs/spec/self-improvement-mode-design.md
+
+---
+
+## 背景
+
+学習ループ監査（2026-08-08）の結論: 記録・構造化・ゲーティングは業界水準超だが、
+「書き出したルールが行動を変えたか」を測る仕組み（効果検証）と、効かないルールを
+捨てる仕組み（剪定）が存在しない。
+
+- **F-1 検証不在**: `verified` ステータスが未運用。sprint-27 レトロには「ルール化した
+  当人が同一セッション内で同じ落とし穴を踏んだ」記録があり、プロンプト追記が
+  行動を変えない実証がループ内に存在する。
+- **F-2 優先度式の欠陥**: severity×frequency は構造的再発問題を過小評価。
+  全4軸PASSのスプリントで priority 9 の教訓が2件発生してもルーブリック改訂の
+  メタ手続きがない。
+- **F-3 剪定不在**: ルールは末尾追記のみ。`pm-learned-rules.md` は既に **983行** あり、
+  指示ファイルの遵守率が低下するとされる 100〜150 行を大幅に超過している。
+
+効果検証の定義（本提案のスコープ）:
+
+1. **再発の測定** — 書いたルールで同じ失敗が起きなくなったかを数える
+2. **効かないルールの処分** — 再発したルールは「無効」と判定し、プロンプトより
+   強い手段（コード化）へ格上げするか、削除する
+
+---
+
+## Sora レビューで v1 から変更した点
+
+| 指摘 | 重大度 | v2 での反映 |
+|------|--------|------------|
+| 2. 「再発なし2スプリント」を数える状態保持機構がない | 高 | `_lessons.json` に `verification_streak` / `last_recurrence_sprint` フィールドを追加（タスク L0-1） |
+| 3. 再発検知条件の必須化がプロンプト任せ（F-1と同型の罠） | 高 | `lessons.sh add` に `--recurrence-condition` 必須オプションを追加しコードでゲート（タスク L0-2） |
+| 4. `pm-learned-rules.md` は983行で目標の6〜10倍 | 高 | 初回大掃除を Level 2 の運用から切り離し、独立した M〜L タスクとして計上（タスク L2-1） |
+| 5. スキーマ文書が実装から乖離（status/scope/stack/source_repo 未定義） | 中 | `enforcement` 追加時に既存4フィールドも含めてスキーマ文書を実装に追いつかせる（タスク L0-1 に統合） |
+| 6. `audit-scan.sh` 自身が `readlink -f` に依存（検出器自身のバグ） | 中 | 検出追加の前提タスクとして自身の修正を明記（タスク L1-1） |
+| 7. `queue.py done` への git status 警告は repo ルート解決が必要 | 中 | `git rev-parse --show-toplevel` による明示的なルート解決を実装要件に明記（タスク L1-2） |
+| 8. `enforcement: code` だけでは二重管理を防げない（書き出しフロー2箇所が enforcement を見ない） | 中 | retro.md Step 5 / `propose-lesson-rules.sh` に skip 分岐を追加。振り分け判断者は「みゆきちが即時判断し、Yuki が自己改善モードで再点検」と定義（タスク L1-4） |
+| 9. ルーブリック改訂自動起票の閾値が1スプリント分のデータしかない | 低 | 2スプリントの試験運用（発火頻度の観察）を経て正式化する条件を明記 |
+| 10. F-1 引用の「再発」は同一セッション内の即時反復 | 低 | 背景の記述を修正済み（上記 F-1） |
+
+---
+
+## Level 0 — 再発チェックの基盤（次スプリント、S規模×3）
+
+「コードほぼ不要」ではなく **小規模な実装を含む** ことを明確化する（Sora 指摘2・3）。
+
+1. **スキーマ拡張＋文書の実装追いつき**（L0-1, Alex 設計 → Riku 実装）
+   - `Lesson` に追加: `recurrence_condition`（string, ルール書き出し対象では必須）、
+     `verification_streak`（int, 再発なし連続スプリント数）、
+     `last_recurrence_sprint`（string|null）、`enforcement`（`code|prompt|process`）
+   - 既存の実装済みフィールド `status` / `scope` / `stack` / `source_repo` を
+     スキーマ文書に追記し、`additionalProperties: false` と実装の整合を回復する
+2. **lessons.sh のゲート化**（L0-2, Riku）
+   - `add` に `--recurrence-condition` オプション追加。`--type failure` かつ
+     priority>=3（ルール書き出し対象）では未指定をエラーにする（最小文字数チェック付き）
+   - `verify-check <sprint>` サブコマンド追加: 対象 lesson の streak を機械更新
+     （再発報告があれば 0 リセット＋`last_recurrence_sprint` 更新、なければ +1、
+     streak>=2 で `verified` へ自動遷移）
+3. **retro.md への再発チェックステップ追加**（L0-3, Alex）
+   - 「前スプリントまでに書き出したルールを列挙し、今スプリントの failure lesson と
+     突合 → `lessons.sh verify-check` を実行」を正式ステップ化
+   - メタ評価ルールを追記: 「全軸PASSかつ priority>=6 の教訓が2件以上 →
+     ルーブリック改訂タスクの起票を提案する」。**2スプリントは試験運用**とし、
+     発火頻度を観察してから正式化する（Sora 指摘9）
+
+## Level 1 — 機械化ゲート（次スプリント〜次々スプリント、S規模×4）
+
+原則: **script/lint/hook で強制可能な教訓はプロンプトに書かずコードにする。**
+コード化された教訓は再発検証が不要になる（テストが通れば効いている）。
+
+1. **audit-scan.sh の readlink 修正＋検出追加**（L1-1, Riku）
+   - 前提: 自身の symlink チェック（3.2節）の `readlink -f` 依存を python3 realpath 等で
+     置換（BSD readlink での偽陽性 FAIL を解消）— Sora 指摘6
+   - その上で、リポジトリ内スクリプトの `readlink -f` 使用を検出する項目を追加
+   - reliability-002 を `enforcement: code` へ更新
+2. **queue.py done の未コミット警告**（L1-2, Riku）
+   - `git rev-parse --show-toplevel` で repo ルートを明示解決した上で
+     `git status --porcelain` を確認し、差分があれば警告表示（ブロックはしない）
+   - 全体差分しか見られない制約（タスク関連差分との区別不可）は既知の制約として
+     notes に明記 — Sora 指摘7
+   - reliability-003 を `enforcement: code` へ更新
+3. **source_repo 正規化**（L1-3, Riku）
+   - `lessons.sh` 内で SSH/HTTPS 形式を正規化（比較・保存の両方）
+   - tooling-001 を `enforcement: code` へ更新（priority 2 だが構造的再発が確定して
+     いるため機械化対象とする — F-2 の運用補正）
+4. **enforcement 分岐の統合**（L1-4, Alex 設計 → Riku 実装）
+   - retro.md Step 5 と `propose-lesson-rules.sh` の抽出条件に
+     「`enforcement == "code"` は書き出しスキップ（コード化タスクへ誘導）」を追加
+   - 振り分け判断者: みゆきちがレトロ時に即時判断、Yuki が自己改善モードで再点検
+
+## Level 2 — 剪定と実測データ（Level 1 完了後）
+
+1. **pm-learned-rules.md 初回大掃除**（L2-1, **独立 M〜L タスク**、Alex 主担当＋Yuki レビュー）
+   - 983行 → 目標100〜150行。verified 済み・機械化済みは削除、類似ルールは抽象化して統合
+   - 削除したルールの根拠は `_lessons.json`（台帳）に残るため情報は失われない
+   - Sora 指摘4により Level 2 の定常運用とは別タスクとして計上
+2. **定常棚卸し**（L2-2, みゆきち）
+   - 3スプリントに1回、レトロの一部として実施。ファイル行数上限を retro.md に明記
+3. **/insights 月次実行**（L2-3, Yuki 運用ルール）
+   - facets 由来の実測データ（繰り返し指示・中断・ツール失敗）を自己改善モードの
+     入力に追加し、エージェント自己報告との差分を分析する
+
+## Level 3 — 本格 eval 基盤: 導入しない
+
+ルールあり/なしのA/B並列実行・エージェント別 component-level eval・trajectory 分析の
+自動化は、個人開発の規模ではコストが効果に見合わないため導入しない。
+（例外の「ルーブリック改訂の自動起票」は L0-3 に試験運用として統合済み）
+
+---
+
+## タスク一覧（スプリント計画への取り込み用）
+
+| # | slug | 担当 | 依存 | complexity | 内容 |
+|---|------|------|------|------------|------|
+| 1 | verify-schema-design | Alex | なし | S | L0-1 設計: スキーマ拡張＋文書の実装追いつき |
+| 2 | lessons-verify-impl | Riku | #1 | M | L0-1/L0-2 実装: フィールド追加・--recurrence-condition ゲート・verify-check |
+| 3 | retro-verify-step | Alex | #1 | S | L0-3: retro.md 再発チェックステップ＋メタ評価ルール（試験運用） |
+| 4 | audit-scan-readlink-fix | Riku | なし | S | L1-1: 自身の readlink 修正＋検出追加 |
+| 5 | queue-done-git-guard | Riku | なし | S | L1-2: done 時の未コミット警告（ルート解決付き） |
+| 6 | lessons-source-repo-normalize | Riku | なし | S | L1-3: source_repo SSH/HTTPS 正規化 |
+| 7 | enforcement-gate-design | Alex | #1 | S | L1-4 設計: 書き出しスキップ分岐＋判断フロー |
+| 8 | enforcement-gate-impl | Riku | #7 | S | L1-4 実装: retro.md Step5 / propose-lesson-rules.sh 改修 |
+| 9 | verify-loop-qa | Sora | #2,#3,#4,#5,#6,#8 | M | 横断QA: 全実装の検証（pytest 追加必須） |
+| 10 | verify-loop-retro | みゆきち | #9 | S | レトロ（初回の再発チェックステップ実運用を兼ねる） |
+
+合計ポイント目安: 13 pt（S×8=8pt + M×2=4pt +α）。
+L2-1（pm-learned-rules 大掃除, M〜L）は負荷分散の観点から**次々スプリント**に送る。
+
+## 成功条件（このプロジェクト自体の効果検証）
+
+- 2スプリント後: `verified` へ遷移した lesson が1件以上存在する
+- 3スプリント後: `enforcement: code` の教訓について同型再発ゼロ
+- 4スプリント後: `pm-learned-rules.md` が150行以下で維持されている

--- a/docs/spec/lessons-json-schema.md
+++ b/docs/spec/lessons-json-schema.md
@@ -1,8 +1,10 @@
 # `_lessons.json` スキーマ設計
 
 作成日: 2026-04-21
+最終更新: 2026-08-08（v1.1.0 — 効果検証フィールド追加＋実装済みフィールドの文書反映）
 ステータス: Accepted
 対応 Issue: #21
+関連: docs/spec/learning-loop-verification-proposal.md（効果検証の導入）
 
 ---
 
@@ -170,6 +172,51 @@ priority_score = severity_score × frequency_score
           "default": null,
           "examples": ["https://github.com/owner/agent-crew/issues/34"]
         },
+        "status": {
+          "type": "string",
+          "description": "lesson のライフサイクル。verified への遷移は lessons.sh verify-check が行う",
+          "enum": ["proposed", "issue_created", "implemented", "verified", "dismissed"],
+          "default": "proposed"
+        },
+        "scope": {
+          "type": "string",
+          "description": "知見の適用範囲",
+          "enum": ["project", "global", "stack"],
+          "default": "project"
+        },
+        "stack": {
+          "type": ["string", "null"],
+          "description": "scope=stack の場合の技術スタック名（例: go, next, vue）",
+          "default": null
+        },
+        "source_repo": {
+          "type": "string",
+          "description": "由来リポジトリ URL。HTTPS 形式に正規化して保存する（SSH 形式は lessons.sh が自動変換）。ローカルのみの場合は \"local\"",
+          "examples": ["https://github.com/Andryu/agent-crew"]
+        },
+        "recurrence_condition": {
+          "type": ["string", "null"],
+          "description": "再発検知条件: 何が観測されなくなったら効いたと言えるか。type=failure かつ priority_score>=3（ルール書き出し対象）では必須（lessons.sh add がコードで強制）",
+          "default": null,
+          "examples": ["PM経由でないタスク指示が発生しない"]
+        },
+        "enforcement": {
+          "type": "string",
+          "description": "教訓の強制手段。code = script/lint/hook で機械的に強制済み（プロンプト書き出し対象外）/ prompt = エージェント .md への行動指針 / process = 人間・運用手順",
+          "enum": ["code", "prompt", "process"],
+          "default": "prompt"
+        },
+        "verification_streak": {
+          "type": "integer",
+          "description": "再発なしで経過した連続スプリント数。lessons.sh verify-check が更新し、2 に達すると status が verified へ自動遷移する。再発時は 0 にリセット",
+          "minimum": 0,
+          "default": 0
+        },
+        "last_recurrence_sprint": {
+          "type": ["string", "null"],
+          "description": "最後に同型再発が観察されたスプリント。非 null の lesson は「プロンプトのルールが効かなかった」実績であり機械化（enforcement: code）の候補",
+          "default": null
+        },
         "supersedes": {
           "type": ["string", "null"],
           "description": "この lesson が更新・改訂する旧 lesson の id（append-only 更新時に使用）",
@@ -232,6 +279,26 @@ priority_score = severity_score × frequency_score
 | 1 | 稀（このスプリントで初めて観察） | 1回 |
 | 2 | 時々（2〜3スプリントに1回程度） | 2〜3回 |
 | 3 | 頻繁（毎スプリントのように発生） | 4回以上 |
+
+### 効果検証フィールドのライフサイクル（v1.1.0）
+
+「記録したルールが行動を変えたか」を再発カウントで測る（learning-loop-verification-proposal.md）。
+
+```
+add（type=failure, priority>=3 → recurrence_condition 必須）
+     │  verification_streak = 0
+     ▼
+レトロで lessons.sh verify-check <sprint> [--recurred <id>]... を実行
+     │
+     ├─ 再発なし → streak +1 ──→ streak >= 2 で status=verified（効いた）
+     │
+     └─ --recurred 指定 → streak=0 / last_recurrence_sprint 更新
+                          verified 済みなら implemented へ差し戻し
+                          → プロンプトのルールでは防げない実績 = 機械化（enforcement: code）候補
+```
+
+`enforcement: code` になった lesson はプロンプト書き出し（retro.md ステップ5 /
+propose-lesson-rules.sh）の対象外となり、二重管理を防ぐ。
 
 ### id 命名規則
 

--- a/scripts/audit-scan.sh
+++ b/scripts/audit-scan.sh
@@ -63,7 +63,7 @@ done
 
 # ---------- 前提コマンドの確認（実行前提エラー = exit 2） ----------
 
-for cmd in jq git find readlink; do
+for cmd in jq git find readlink python3; do
   if ! command -v "$cmd" >/dev/null 2>&1; then
     echo "ERROR: 前提コマンドが見つかりません: $cmd" >&2
     exit 2
@@ -168,7 +168,10 @@ if [[ -n "$SYMLINKS" ]]; then
       continue
     fi
 
-    resolved=$(readlink -f "$link" 2>/dev/null || true)
+    # readlink -f は macOS 標準（BSD readlink）非対応のため使用しない
+    # （agent-crew-sprint-27-reliability-002 / Sora指摘6: 検出器自身が同バグを抱えていた）。
+    # python3 の os.path.realpath で代替する（POSIX/macOS 両対応）。
+    resolved=$(python3 -c 'import os, sys; print(os.path.realpath(sys.argv[1]))' "$link" 2>/dev/null || true)
     raw_target=$(readlink "$link" 2>/dev/null || true)
     if [[ -z "$resolved" ]] || [[ "$raw_target" == "$link" ]]; then
       SYMLINK_DETAIL_LINES+=("[FAIL] ${rel_link} — 自己参照（ループ）の疑い")
@@ -369,6 +372,36 @@ else
 fi
 
 # ========================================================================
+# 3.7 readlink -f 非移植性チェック（agent-crew-sprint-27-reliability-002 / enforcement: code）
+# ========================================================================
+# macOS 標準の BSD readlink は -f オプション非対応のため、リポジトリ内の
+# シェルスクリプトでの `readlink -f` 使用を検出する。代替: python3 の os.path.realpath。
+
+PORTABILITY_RESULT="PASS"
+PORTABILITY_FAIL_COUNT=0
+PORTABILITY_DETAIL_LINES=()
+
+SELF_NAME=$(basename "$0")
+PORTABILITY_HITS=$(grep -rnE 'readlink[[:space:]]+-f' \
+  "$REPO_ROOT/scripts" "$REPO_ROOT/hooks" "$REPO_ROOT"/install*.sh "$REPO_ROOT/build.sh" \
+  2>/dev/null | grep -v "/${SELF_NAME}:" || true)
+
+if [[ -n "$PORTABILITY_HITS" ]]; then
+  while IFS= read -r hit; do
+    [[ -z "$hit" ]] && continue
+    rel_hit="${hit#"$REPO_ROOT"/}"
+    PORTABILITY_DETAIL_LINES+=("[FAIL] ${rel_hit%%:*}:$(echo "$rel_hit" | cut -d: -f2) — readlink -f は macOS(BSD readlink) 非対応。python3 -c 'import os,sys; print(os.path.realpath(sys.argv[1]))' で代替する")
+    PORTABILITY_FAIL_COUNT=$((PORTABILITY_FAIL_COUNT + 1))
+  done <<< "$PORTABILITY_HITS"
+fi
+
+if [[ "$PORTABILITY_FAIL_COUNT" -gt 0 ]]; then
+  PORTABILITY_RESULT="FAIL (${PORTABILITY_FAIL_COUNT}件)"
+else
+  PORTABILITY_DETAIL_LINES+=("該当なし")
+fi
+
+# ========================================================================
 # レポート生成
 # ========================================================================
 
@@ -377,7 +410,8 @@ SHORT_SHA=$(git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 
 OVERALL="PASS"
 if [[ "$PERM_RESULT" == "FAIL" || "$SYMLINK_RESULT" == FAIL* || "$HOOKS_RESULT" == FAIL* \
-   || "$CIRCUIT_RESULT" == FAIL* || "$TOKEN_RESULT" == FAIL* || "$FORBIDDEN_RESULT" == FAIL* ]]; then
+   || "$CIRCUIT_RESULT" == FAIL* || "$TOKEN_RESULT" == FAIL* || "$FORBIDDEN_RESULT" == FAIL* \
+   || "$PORTABILITY_RESULT" == FAIL* ]]; then
   OVERALL="FAIL"
 fi
 
@@ -397,6 +431,7 @@ REPORT=$(
   echo "| サーキットブレーカー健全性 | ${CIRCUIT_RESULT} |"
   echo "| トークン予算超過 | ${TOKEN_RESULT} |"
   echo "| 禁止コマンド | ${FORBIDDEN_RESULT} |"
+  echo "| readlink -f 非移植性 | ${PORTABILITY_RESULT} |"
   echo ""
   echo "## 詳細"
   echo ""
@@ -427,6 +462,11 @@ REPORT=$(
   echo ""
   echo "### 禁止コマンド（ガードレール第4条）"
   for line in "${FORBIDDEN_DETAIL_LINES[@]}"; do
+    echo "- ${line}"
+  done
+  echo ""
+  echo "### readlink -f 非移植性（agent-crew-sprint-27-reliability-002）"
+  for line in "${PORTABILITY_DETAIL_LINES[@]}"; do
     echo "- ${line}"
   done
   echo ""

--- a/scripts/lessons.sh
+++ b/scripts/lessons.sh
@@ -17,10 +17,22 @@
 #     [--evidence "<evidence1>" --evidence "<evidence2>" ...] \
 #     [--tags "<tag1>" --tags "<tag2>" ...] \
 #     [--issue-url <url>] \
-#     [--supersedes <id>]
+#     [--supersedes <id>] \
+#     [--recurrence-condition "<condition>"] \
+#     [--enforcement <code|prompt|process>] \
+#     [--source-repo <url>]
 #
 #   lessons.sh set-status <id> <proposed|issue_created|implemented|verified|dismissed>
 #   lessons.sh promote <id> <project|global|stack> [<stack>]
+#   lessons.sh verify-check <current-sprint> [--recurred <id>]...
+#
+#   verify-check: 効果検証（learning-loop-verification-proposal.md L0-2）。
+#     過去スプリントのルール書き出し対象 lesson（type=failure, priority>=3,
+#     status が proposed/issue_created/implemented）について:
+#       --recurred で指定された lesson → verification_streak を 0 にリセットし
+#         last_recurrence_sprint を現スプリントに更新（ルール無効 = 機械化候補）
+#       それ以外 → verification_streak を +1。streak >= 2 に達したら
+#         status を verified へ自動遷移する
 #
 # 環境変数:
 #   LESSONS_FILE   lessons ファイルパス (default: ~/.claude/_lessons.json)
@@ -60,6 +72,13 @@ add options:
   --tags         自由タグ (複数指定可)
   --issue-url    対応 GitHub Issue の URL
   --supersedes   改訂対象の旧 lesson ID
+  --recurrence-condition
+                 再発検知条件: 何が観測されなくなったら効いたと言えるか
+                 (type=failure かつ priority_score>=3 では必須、10文字以上)
+  --enforcement  code|prompt|process (省略時: prompt)
+                 code = script/lint/hook で強制済み。プロンプト書き出し対象外になる
+  --source-repo  由来リポジトリURL (省略時: git remote get-url origin。
+                 SSH形式は HTTPS 形式へ自動正規化される)
   --help         このヘルプを表示
 
 set-status args:
@@ -70,8 +89,26 @@ promote args:
   <id>           lesson ID (必須)
   <scope>        project|global|stack (必須)
   <stack>        スタック名 (scope=stack時に必須)
+
+verify-check args:
+  <current-sprint>  現スプリント識別子 例: sprint-28 (必須)
+  --recurred <id>   今スプリントで同型再発が観察された lesson ID (複数指定可)
 HELP_EOF
   exit 1
+}
+
+# source_repo 正規化: SSH形式 (git@github.com:owner/repo.git) を
+# HTTPS形式 (https://github.com/owner/repo) に統一する。
+# agent-crew-sprint-27-tooling-001 の恒久対応（enforcement: code）。
+normalize_source_repo() {
+  local url="$1"
+  url="${url%.git}"
+  if [[ "$url" =~ ^git@([^:]+):(.+)$ ]]; then
+    url="https://${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  elif [[ "$url" =~ ^ssh://git@([^/]+)/(.+)$ ]]; then
+    url="https://${BASH_REMATCH[1]}/${BASH_REMATCH[2]}"
+  fi
+  echo "$url"
 }
 
 die() {
@@ -105,8 +142,8 @@ if [[ "$CMD" == "--help" || "$CMD" == "-h" || -z "$CMD" ]]; then
   usage
 fi
 
-if [[ "$CMD" != "add" && "$CMD" != "set-status" && "$CMD" != "promote" ]]; then
-  die "unknown command: '$CMD'. Use 'add', 'set-status', or 'promote'."
+if [[ "$CMD" != "add" && "$CMD" != "set-status" && "$CMD" != "promote" && "$CMD" != "verify-check" ]]; then
+  die "unknown command: '$CMD'. Use 'add', 'set-status', 'promote', or 'verify-check'."
 fi
 
 SET_STATUS_ID=""
@@ -114,6 +151,8 @@ SET_STATUS_VAL=""
 PROMOTE_ID=""
 PROMOTE_SCOPE=""
 PROMOTE_STACK="null"
+VERIFY_SPRINT=""
+RECURRED_IDS=()
 
 if [[ "$CMD" == "set-status" ]]; then
   SET_STATUS_ID="${1:-}"
@@ -124,6 +163,16 @@ elif [[ "$CMD" == "promote" ]]; then
   if [[ "$PROMOTE_SCOPE" == "stack" ]]; then
     PROMOTE_STACK="\"${3:-}\""
   fi
+elif [[ "$CMD" == "verify-check" ]]; then
+  VERIFY_SPRINT="${1:-}"
+  shift || true
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --recurred) RECURRED_IDS+=("$2"); shift 2 ;;
+      --help|-h)  usage ;;
+      *) die "unknown option for verify-check: '$1'" ;;
+    esac
+  done
 fi
 
 PROJECT=""
@@ -139,6 +188,9 @@ SCOPE="project"
 STACK="null"
 ISSUE_URL="null"
 SUPERSEDES="null"
+RECURRENCE_CONDITION=""
+ENFORCEMENT="prompt"
+SOURCE_REPO=""
 EVIDENCE_ITEMS=()
 TAG_ITEMS=()
 
@@ -158,6 +210,9 @@ while [[ $# -gt 0 ]]; do
     --stack)       STACK="\"$2\"";    shift 2 ;;
     --issue-url)   ISSUE_URL="\"$2\""; shift 2 ;;
     --supersedes)  SUPERSEDES="\"$2\""; shift 2 ;;
+    --recurrence-condition) RECURRENCE_CONDITION="$2"; shift 2 ;;
+    --enforcement) ENFORCEMENT="$2";  shift 2 ;;
+    --source-repo) SOURCE_REPO="$2";  shift 2 ;;
     --evidence)    EVIDENCE_ITEMS+=("$2"); shift 2 ;;
     --tags)        TAG_ITEMS+=("$2"); shift 2 ;;
     --help|-h)     usage ;;
@@ -206,6 +261,32 @@ if [[ "$CMD" == "add" ]]; then
     || die "--description must be at least 10 characters"
   [[ ${#ACTION} -ge 5 ]] \
     || die "--action must be at least 5 characters"
+
+  [[ "$ENFORCEMENT" =~ ^(code|prompt|process)$ ]] \
+    || die "--enforcement must be code, prompt, or process, got: '$ENFORCEMENT'"
+
+  # 再発検知条件ゲート（learning-loop-verification-proposal.md L0-2 / Sora指摘3）:
+  # ルール書き出し対象（type=failure かつ priority>=3）では、
+  # 「何が観測されなくなったら効いたと言えるか」の明文化をコードで強制する。
+  if [[ "$TYPE" == "failure" && $(( SEVERITY * FREQUENCY )) -ge 3 ]]; then
+    [[ -n "$RECURRENCE_CONDITION" ]] \
+      || die "--recurrence-condition is required for failure lessons with priority_score >= 3 (何が観測されなくなったら効いたと言えるかを書く)"
+    [[ ${#RECURRENCE_CONDITION} -ge 10 ]] \
+      || die "--recurrence-condition must be at least 10 characters"
+  fi
+
+  # source_repo: 未指定なら origin から取得し、SSH形式は HTTPS へ正規化する
+  if [[ -z "$SOURCE_REPO" ]]; then
+    SOURCE_REPO=$(git remote get-url origin 2>/dev/null || echo "local")
+  fi
+  SOURCE_REPO=$(normalize_source_repo "$SOURCE_REPO")
+fi
+
+# ---------- バリデーション (verify-check) ----------
+if [[ "$CMD" == "verify-check" ]]; then
+  [[ -n "$VERIFY_SPRINT" ]] || die "verify-check requires <current-sprint> argument"
+  [[ "$VERIFY_SPRINT" =~ ^sprint-[0-9]+$ ]] \
+    || die "verify-check sprint must match 'sprint-NNN', got: '$VERIFY_SPRINT'"
 fi
 
 # ---------- バリデーション (promote) ----------
@@ -337,6 +418,11 @@ _do_add() {
     tags_json=$(printf '%s\n' "${TAG_ITEMS[@]}" | jq -R . | jq -s .)
   fi
 
+  local recurrence_json="null"
+  if [[ -n "$RECURRENCE_CONDITION" ]]; then
+    recurrence_json=$(jq -n --arg c "$RECURRENCE_CONDITION" '$c')
+  fi
+
   new_entry=$(jq -n \
     --arg id           "$id" \
     --arg project      "$PROJECT" \
@@ -356,6 +442,9 @@ _do_add() {
     --arg status       "$STATUS" \
     --argjson supersedes "$SUPERSEDES" \
     --arg created_at   "$created_at" \
+    --arg source_repo  "$SOURCE_REPO" \
+    --argjson recurrence_condition "$recurrence_json" \
+    --arg enforcement  "$ENFORCEMENT" \
     '{
       id:              $id,
       project:         $project,
@@ -374,6 +463,11 @@ _do_add() {
       status:          $status,
       supersedes:      $supersedes,
       tags:            $tags,
+      source_repo:     $source_repo,
+      recurrence_condition: $recurrence_condition,
+      enforcement:     $enforcement,
+      verification_streak: 0,
+      last_recurrence_sprint: null,
       created_at:      $created_at,
       updated_at:      null
     }'
@@ -388,6 +482,88 @@ _do_add() {
   echo "$id"
 }
 
+_do_verify_check() {
+  local current_sprint="$1"
+  shift
+  local recurred_json existing updated tmp updated_at
+
+  existing=$(cat "$LESSONS_FILE")
+  updated_at=$(date -u +"%Y-%m-%dT%H:%M:%S+0000")
+
+  # --recurred で渡された ID を JSON 配列へ
+  if [[ $# -eq 0 ]]; then
+    recurred_json="[]"
+  else
+    recurred_json=$(printf '%s\n' "$@" | jq -R . | jq -s .)
+  fi
+
+  # 指定 ID の存在チェック（typo で無言スキップしないため）
+  local missing
+  missing=$(jq -r --argjson ids "$recurred_json" '
+    ($ids - [.lessons[].id]) | .[]' <<< "$existing")
+  [[ -z "$missing" ]] || die "verify-check: lesson not found: $missing"
+
+  # 効果検証の対象 = ルール書き出し対象（type=failure, priority>=3）で
+  # 現スプリントより前に記録されたもの。
+  # - recurred に含まれる → streak を 0 リセット、last_recurrence_sprint 更新。
+  #   verified 済みだった場合は implemented へ差し戻す（検証済みルールの破れ）
+  # - 含まれない（未確定ステータスのみ）→ streak +1。streak >= 2 で
+  #   status=verified へ自動遷移
+  updated=$(jq \
+    --arg current    "$current_sprint" \
+    --arg updated_at "$updated_at" \
+    --argjson recurred "$recurred_json" \
+    '
+    def rule_target:
+      ((.type // "failure") == "failure")
+      and ((.priority_score // 0) >= 3)
+      and (.sprint != $current);
+    def open_status:
+      (.status // "proposed") | IN("proposed", "issue_created", "implemented", "open");
+    .lessons |= map(
+      if (rule_target and ([.id] | inside($recurred))) then
+        .verification_streak = 0
+        | .last_recurrence_sprint = $current
+        | (if .status == "verified" then .status = "implemented" else . end)
+        | .updated_at = $updated_at
+      elif (rule_target and open_status) then
+        .verification_streak = ((.verification_streak // 0) + 1)
+        | (if .verification_streak >= 2 then .status = "verified" else . end)
+        | .updated_at = $updated_at
+      else . end
+    )' \
+    <<< "$existing")
+
+  tmp=$(mktemp "${LESSONS_FILE}.tmp.XXXXXX")
+  echo "$updated" > "$tmp"
+  mv "$tmp" "$LESSONS_FILE"
+
+  # サマリー出力: 実行前後の diff で判定する
+  # （updated_at のタイムスタンプ比較は秒精度のため同一秒の連続実行で誤報告するリスクがある）
+  jq -rn \
+    --argjson before "$existing" \
+    --argjson after  "$updated" \
+    --arg current "$current_sprint" '
+    ($before.lessons | map({key: .id, value: .}) | from_entries) as $b
+    | [$after.lessons[]
+       | . as $l
+       | $b[$l.id] as $old
+       | select($old != null and (
+           (($l.verification_streak // 0) != ($old.verification_streak // 0))
+           or ($l.status != $old.status)
+           or ($l.last_recurrence_sprint != $old.last_recurrence_sprint)
+         ))
+      ] as $touched
+    | [$touched[] | select(.last_recurrence_sprint == $current)] as $reset
+    | [$touched[] | select(.status == "verified" and .last_recurrence_sprint != $current)] as $verified
+    | [$touched[] | select(.status != "verified" and .last_recurrence_sprint != $current)] as $progress
+    | "verify-check (\($current)):",
+      "  再発リセット: \($reset | length) 件\(if ($reset|length) > 0 then " → 機械化候補: " + ([$reset[].id] | join(", ")) else "" end)",
+      "  verified 遷移: \($verified | length) 件\(if ($verified|length) > 0 then " → " + ([$verified[].id] | join(", ")) else "" end)",
+      "  streak 進行中: \($progress | length) 件"
+  '
+}
+
 # ---------- コマンド実行 ----------
 
 execute_with_lock() {
@@ -395,34 +571,48 @@ execute_with_lock() {
   shift
   local result
   
+  # 注意: 呼び出し側が `|| exit` で受けると set -e が本関数内で無効化されるため、
+  # コマンド置換の失敗を明示的に return で伝搬させる（暗黙の set -e に頼らない）。
+  local rc=0
   if command -v flock >/dev/null 2>&1; then
     result=$(
       (
         flock -x -w "$LOCK_TIMEOUT" 200 || die "lock timeout (${LOCK_TIMEOUT}s). Another process may be writing."
         "$cmd_func" "$@"
       ) 200>"$LOCK_FILE"
-    )
+    ) || rc=$?
   else
     acquire_mkdir_lock
     trap release_mkdir_lock EXIT INT TERM
-    result=$("$cmd_func" "$@")
+    result=$("$cmd_func" "$@") || rc=$?
     trap - EXIT INT TERM
     release_mkdir_lock
   fi
+  [[ $rc -eq 0 ]] || return $rc
   echo "$result"
 }
 
+# 注意: _do_* 内の die はロック用 subshell 内で発火するため、
+# 呼び出し側で || exit を明示しないと失敗が exit 0 に化ける。
 if [[ "$CMD" == "set-status" ]]; then
-  result=$(execute_with_lock _do_set_status "$SET_STATUS_ID" "$SET_STATUS_VAL")
+  result=$(execute_with_lock _do_set_status "$SET_STATUS_ID" "$SET_STATUS_VAL") || exit $?
   echo "$result"
   exit 0
 elif [[ "$CMD" == "promote" ]]; then
-  result=$(execute_with_lock _do_promote "$PROMOTE_ID" "$PROMOTE_SCOPE" "$PROMOTE_STACK")
+  result=$(execute_with_lock _do_promote "$PROMOTE_ID" "$PROMOTE_SCOPE" "$PROMOTE_STACK") || exit $?
   echo "$result"
   exit 0
 elif [[ "$CMD" == "add" ]]; then
-  result=$(execute_with_lock _do_add)
+  result=$(execute_with_lock _do_add) || exit $?
   echo "Added lesson: $result"
+  exit 0
+elif [[ "$CMD" == "verify-check" ]]; then
+  if [[ ${#RECURRED_IDS[@]} -eq 0 ]]; then
+    result=$(execute_with_lock _do_verify_check "$VERIFY_SPRINT") || exit $?
+  else
+    result=$(execute_with_lock _do_verify_check "$VERIFY_SPRINT" "${RECURRED_IDS[@]}") || exit $?
+  fi
+  echo "$result"
   exit 0
 fi
 

--- a/scripts/propose-lesson-rules.sh
+++ b/scripts/propose-lesson-rules.sh
@@ -80,6 +80,9 @@ fi
 
 log "Extracting lessons with priority_score >= $MIN_PRIORITY ..."
 
+# enforcement == "code" はプロンプト書き出し対象外:
+# script/lint/hook で機械的に強制済みの教訓をエージェント .md にも書くと
+# 二重管理になるため（learning-loop-verification-proposal.md L1-4）。
 LESSONS_JSON=$(jq -c --argjson min "$MIN_PRIORITY" '
   .lessons[]
   | select(
@@ -90,6 +93,7 @@ LESSONS_JSON=$(jq -c --argjson min "$MIN_PRIORITY" '
         or .status == "proposed"
         or .status == "issue_created"
       )
+      and ((.enforcement // "prompt") != "code")
     )
 ' "$LESSONS_FILE" 2>/dev/null || echo "")
 

--- a/scripts/queue.py
+++ b/scripts/queue.py
@@ -188,6 +188,42 @@ def calculate_risk(task: Task) -> None:
     typer.echo(f"  retry_count: {retry}", err=True)
 
 
+def warn_uncommitted_work(slug: str) -> None:
+    """タスク完了時に未コミット差分があれば stderr へ警告する（非ブロック）。
+
+    agent-crew-sprint-27-reliability-003（未コミット作業の保護漏れ）の恒久対応
+    （enforcement: code / learning-loop-verification-proposal.md L1-2）。
+    repo ルートは _queue.json の位置から明示的に解決する（CWD 依存の誤判定防止）。
+    既知の制約: git status は作業ツリー全体の差分を返すため、
+    このタスクに関係する差分だけを区別することはできない。
+    """
+    try:
+        anchor = QUEUE_FILE.resolve().parent
+        root_proc = subprocess.run(
+            ["git", "-C", str(anchor), "rev-parse", "--show-toplevel"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if root_proc.returncode != 0:
+            return
+        repo_root = root_proc.stdout.strip()
+        status_proc = subprocess.run(
+            ["git", "-C", repo_root, "status", "--porcelain"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if status_proc.returncode != 0:
+            return
+        dirty = [line for line in status_proc.stdout.splitlines() if line.strip()]
+        if dirty:
+            typer.echo(
+                f"WARNING: {slug} 完了時点で未コミットの変更が {len(dirty)} 件あります"
+                f"（作業ツリー全体）。セッション中断で成果物が失われる前に commit してください。",
+                err=True,
+            )
+    except Exception:
+        # 警告は best-effort。done 本体の成否に影響させない
+        pass
+
+
 def close_linked_issue(
     q: QueueFile, slug: str, agent: str, summary: str, override_issue: Optional[int] = None
 ) -> None:
@@ -287,6 +323,7 @@ def done(
     typer.echo(f"OK: {slug} → DONE")
     emit_signal("task.done", slug, agent, {"summary": summary})
     close_linked_issue(q, slug, agent, summary, override_issue=close_issue)
+    warn_uncommitted_work(slug)
 
 # ---------- コマンド: handoff ----------
 

--- a/tests/test_lessons_verify.py
+++ b/tests/test_lessons_verify.py
@@ -1,0 +1,227 @@
+"""
+tests/test_lessons_verify.py — lessons.sh 効果検証機能のテスト
+
+learning-loop-verification-proposal.md L0（再発チェック基盤）の検証:
+- --recurrence-condition 必須ゲート（type=failure かつ priority>=3）
+- source_repo の SSH→HTTPS 正規化
+- verify-check の streak 加算 / verified 自動遷移 / 再発リセット
+- enforcement: code のプロンプト書き出しスキップ（propose-lesson-rules.sh）
+実際の ~/.claude/_lessons.json には触れない（tmp_path フィクスチャを使用）。
+"""
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+LESSONS_SH = REPO_ROOT / "scripts" / "lessons.sh"
+PROPOSE_SH = REPO_ROOT / "scripts" / "propose-lesson-rules.sh"
+
+
+@pytest.fixture
+def lessons_file(tmp_path: Path) -> Path:
+    f = tmp_path / "_lessons.json"
+    f.write_text(json.dumps({"schema_version": "1.1.0", "lessons": []}))
+    return f
+
+
+def run_lessons(args: list[str], lessons_file: Path) -> subprocess.CompletedProcess:
+    env = {
+        **os.environ,
+        "LESSONS_FILE": str(lessons_file),
+        "LOCK_FILE": str(lessons_file) + ".lock",
+    }
+    return subprocess.run(
+        ["bash", str(LESSONS_SH)] + args, capture_output=True, text=True, env=env
+    )
+
+
+def add_failure(lessons_file: Path, *, severity="3", frequency="3", extra=None) -> subprocess.CompletedProcess:
+    args = [
+        "add",
+        "--project", "agent-crew",
+        "--sprint", "sprint-27",
+        "--category", "process",
+        "--severity", severity,
+        "--frequency", frequency,
+        "--description", "テスト用の失敗観察エントリです",
+        "--action", "テスト用アクション",
+    ] + (extra or [])
+    return run_lessons(args, lessons_file)
+
+
+def read_lessons(lessons_file: Path) -> list[dict]:
+    return json.loads(lessons_file.read_text())["lessons"]
+
+
+# ---------- 再発検知条件ゲート ----------
+
+class TestRecurrenceConditionGate:
+    def test_failure_high_priority_requires_condition(self, lessons_file):
+        result = add_failure(lessons_file)
+        assert result.returncode == 1
+        assert "--recurrence-condition is required" in result.stderr
+
+    def test_failure_high_priority_with_condition_succeeds(self, lessons_file):
+        result = add_failure(lessons_file, extra=[
+            "--recurrence-condition", "同型のタスク指示衝突が発生しない",
+        ])
+        assert result.returncode == 0, result.stderr
+        entry = read_lessons(lessons_file)[0]
+        assert entry["recurrence_condition"] == "同型のタスク指示衝突が発生しない"
+        assert entry["verification_streak"] == 0
+        assert entry["last_recurrence_sprint"] is None
+        assert entry["enforcement"] == "prompt"
+
+    def test_condition_too_short_rejected(self, lessons_file):
+        result = add_failure(lessons_file, extra=["--recurrence-condition", "短い"])
+        assert result.returncode == 1
+        assert "at least 10 characters" in result.stderr
+
+    def test_low_priority_failure_does_not_require_condition(self, lessons_file):
+        # priority = 1×2 = 2 < 3 → ルール書き出し対象外なので条件不要
+        result = add_failure(lessons_file, severity="1", frequency="2")
+        assert result.returncode == 0, result.stderr
+
+    def test_success_type_does_not_require_condition(self, lessons_file):
+        result = add_failure(lessons_file, extra=["--type", "success"])
+        assert result.returncode == 0, result.stderr
+
+    def test_invalid_enforcement_rejected(self, lessons_file):
+        result = add_failure(lessons_file, extra=[
+            "--recurrence-condition", "同型の事象が発生しない",
+            "--enforcement", "magic",
+        ])
+        assert result.returncode == 1
+        assert "--enforcement must be" in result.stderr
+
+
+# ---------- source_repo 正規化 ----------
+
+class TestSourceRepoNormalization:
+    @pytest.mark.parametrize("raw,expected", [
+        ("git@github.com:Andryu/agent-crew.git", "https://github.com/Andryu/agent-crew"),
+        ("ssh://git@github.com/Andryu/agent-crew.git", "https://github.com/Andryu/agent-crew"),
+        ("https://github.com/Andryu/agent-crew.git", "https://github.com/Andryu/agent-crew"),
+        ("https://github.com/Andryu/agent-crew", "https://github.com/Andryu/agent-crew"),
+    ])
+    def test_ssh_normalized_to_https(self, lessons_file, raw, expected):
+        result = add_failure(lessons_file, extra=[
+            "--recurrence-condition", "同型の事象が発生しない",
+            "--source-repo", raw,
+        ])
+        assert result.returncode == 0, result.stderr
+        assert read_lessons(lessons_file)[-1]["source_repo"] == expected
+
+
+# ---------- verify-check ----------
+
+class TestVerifyCheck:
+    def _seed(self, lessons_file, status="implemented"):
+        result = add_failure(lessons_file, extra=[
+            "--recurrence-condition", "同型の事象が発生しない",
+            "--status", status,
+        ])
+        assert result.returncode == 0, result.stderr
+        return read_lessons(lessons_file)[-1]["id"]
+
+    def test_streak_increments_then_verifies(self, lessons_file):
+        lid = self._seed(lessons_file)
+        r1 = run_lessons(["verify-check", "sprint-28"], lessons_file)
+        assert r1.returncode == 0, r1.stderr
+        assert read_lessons(lessons_file)[0]["verification_streak"] == 1
+        assert read_lessons(lessons_file)[0]["status"] == "implemented"
+
+        r2 = run_lessons(["verify-check", "sprint-29"], lessons_file)
+        assert r2.returncode == 0, r2.stderr
+        entry = read_lessons(lessons_file)[0]
+        assert entry["verification_streak"] == 2
+        assert entry["status"] == "verified"
+        assert lid in r2.stdout  # verified 遷移としてサマリーに出る
+
+    def test_recurred_resets_streak(self, lessons_file):
+        lid = self._seed(lessons_file)
+        run_lessons(["verify-check", "sprint-28"], lessons_file)
+        r = run_lessons(["verify-check", "sprint-29", "--recurred", lid], lessons_file)
+        assert r.returncode == 0, r.stderr
+        entry = read_lessons(lessons_file)[0]
+        assert entry["verification_streak"] == 0
+        assert entry["last_recurrence_sprint"] == "sprint-29"
+        assert "機械化候補" in r.stdout
+
+    def test_recurred_after_verified_reverts_to_implemented(self, lessons_file):
+        # verified 済みルールの破れ: verified → implemented へ差し戻し
+        lid = self._seed(lessons_file)
+        run_lessons(["verify-check", "sprint-28"], lessons_file)
+        run_lessons(["verify-check", "sprint-29"], lessons_file)
+        assert read_lessons(lessons_file)[0]["status"] == "verified"
+
+        r = run_lessons(["verify-check", "sprint-30", "--recurred", lid], lessons_file)
+        assert r.returncode == 0, r.stderr
+        entry = read_lessons(lessons_file)[0]
+        assert entry["status"] == "implemented"
+        assert entry["verification_streak"] == 0
+        assert entry["last_recurrence_sprint"] == "sprint-30"
+
+    def test_same_sprint_lessons_excluded(self, lessons_file):
+        # 現スプリントに記録されたばかりの lesson は streak 加算対象外
+        self._seed(lessons_file)
+        r = run_lessons(["verify-check", "sprint-27"], lessons_file)
+        assert r.returncode == 0, r.stderr
+        assert read_lessons(lessons_file)[0]["verification_streak"] == 0
+
+    def test_low_priority_excluded(self, lessons_file):
+        result = add_failure(lessons_file, severity="1", frequency="2", extra=["--status", "implemented"])
+        assert result.returncode == 0
+        run_lessons(["verify-check", "sprint-28"], lessons_file)
+        assert read_lessons(lessons_file)[0]["verification_streak"] == 0
+
+    def test_unknown_recurred_id_fails(self, lessons_file):
+        self._seed(lessons_file)
+        r = run_lessons(["verify-check", "sprint-28", "--recurred", "no-such-id"], lessons_file)
+        assert r.returncode == 1
+        assert "lesson not found" in r.stderr
+
+    def test_invalid_sprint_format_fails(self, lessons_file):
+        r = run_lessons(["verify-check", "sprint28"], lessons_file)
+        assert r.returncode == 1
+
+    def test_dismissed_not_incremented(self, lessons_file):
+        self._seed(lessons_file, status="dismissed")
+        run_lessons(["verify-check", "sprint-28"], lessons_file)
+        entry = read_lessons(lessons_file)[0]
+        assert entry["verification_streak"] == 0
+        assert entry["status"] == "dismissed"
+
+
+# ---------- enforcement: code のプロンプト書き出しスキップ ----------
+
+class TestEnforcementSkip:
+    def test_propose_lesson_rules_skips_code_enforcement(self, lessons_file, tmp_path):
+        # code / prompt の2エントリを用意
+        for enforcement in ("code", "prompt"):
+            result = add_failure(lessons_file, extra=[
+                "--recurrence-condition", "同型の事象が発生しない",
+                "--enforcement", enforcement,
+            ])
+            assert result.returncode == 0, result.stderr
+        lessons = read_lessons(lessons_file)
+        code_id = next(l["id"] for l in lessons if l["enforcement"] == "code")
+        prompt_id = next(l["id"] for l in lessons if l["enforcement"] == "prompt")
+
+        # propose-lesson-rules.sh は cwd の .claude/agents を見るため tmp に用意
+        agents_dir = tmp_path / ".claude" / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "pm.md").write_text("# pm\n")
+
+        env = {**os.environ, "LESSONS_FILE": str(lessons_file)}
+        r = subprocess.run(
+            ["bash", str(PROPOSE_SH), "--dry-run", "--min-priority", "3"],
+            capture_output=True, text=True, env=env, cwd=tmp_path,
+        )
+        assert r.returncode == 0, r.stderr
+        combined = r.stdout + r.stderr
+        assert prompt_id in combined
+        assert code_id not in combined

--- a/tests/test_queue_done_git_guard.py
+++ b/tests/test_queue_done_git_guard.py
@@ -1,0 +1,105 @@
+"""
+tests/test_queue_done_git_guard.py — queue.py done の未コミット警告テスト
+
+agent-crew-sprint-27-reliability-003（未コミット作業の保護漏れ）の恒久対応
+（learning-loop-verification-proposal.md L1-2）の検証:
+- 作業ツリーに未コミット差分がある状態で done → stderr に WARNING
+- クリーンな作業ツリーで done → WARNING なし
+- git リポジトリ外の queue でも done 自体は成功する（警告は best-effort）
+"""
+import json
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).parent.parent
+
+QUEUE_TEMPLATE = {
+    "sprint": "test-sprint",
+    "tasks": [
+        {
+            "slug": "task-a",
+            "title": "Task A",
+            "status": "IN_PROGRESS",
+            "assigned_to": "Riku",
+            "complexity": "S",
+            "risk_level": "low",
+            "parallel_group": None,
+            "depends_on": [],
+            "qa_mode": None,
+            "created_at": "2026-08-08",
+            "updated_at": "2026-08-08",
+            "notes": "",
+            "retry_count": 0,
+            "qa_result": None,
+            "summary": None,
+            "events": [],
+        }
+    ],
+}
+
+
+def run_done(queue_file: Path) -> subprocess.CompletedProcess:
+    uv = str(Path.home() / ".local/bin/uv")
+    env = {**os.environ, "QUEUE_FILE": str(queue_file)}
+    return subprocess.run(
+        [uv, "run", str(REPO_ROOT / "scripts" / "queue.py"), "done", "task-a", "Riku", "完了"],
+        capture_output=True, text=True, env=env, cwd=REPO_ROOT,
+    )
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """queue ファイルを含む一時 git リポジトリ（初期状態はクリーン）"""
+    repo = tmp_path / "repo"
+    claude_dir = repo / ".claude"
+    claude_dir.mkdir(parents=True)
+    queue_file = claude_dir / "_queue.json"
+    queue_file.write_text(json.dumps(QUEUE_TEMPLATE, ensure_ascii=False))
+    # done 自身が書き込む .claude/（_queue.json / _signals.jsonl）は追跡対象外にして
+    # 「done 実行以外の未コミット差分」だけを検出対象にする
+    (repo / ".gitignore").write_text(".claude/\n")
+    (repo / "README.md").write_text("# test repo\n")
+
+    def git(*args):
+        subprocess.run(
+            ["git", "-C", str(repo), *args], check=True, capture_output=True,
+            env={**os.environ,
+                 "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@example.com",
+                 "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@example.com"},
+        )
+
+    git("init", "-q")
+    git("add", "-A")
+    git("commit", "-q", "-m", "init")
+    return repo
+
+
+class TestDoneGitGuard:
+    def test_warns_on_uncommitted_changes(self, git_repo):
+        queue_file = git_repo / ".claude" / "_queue.json"
+        (git_repo / "orphan.py").write_text("# 未コミット成果物\n")
+        result = run_done(queue_file)
+        assert result.returncode == 0, result.stderr
+        assert "OK: task-a → DONE" in result.stdout
+        assert "未コミットの変更" in result.stderr
+
+    def test_no_warning_when_clean(self, git_repo):
+        queue_file = git_repo / ".claude" / "_queue.json"
+        result = run_done(queue_file)
+        assert result.returncode == 0, result.stderr
+        assert "OK: task-a → DONE" in result.stdout
+        assert "未コミットの変更" not in result.stderr
+
+    def test_done_succeeds_outside_git_repo(self, tmp_path):
+        # git 管理外でも done は成功し、警告も出ない（best-effort）
+        claude_dir = tmp_path / "no-git" / ".claude"
+        claude_dir.mkdir(parents=True)
+        queue_file = claude_dir / "_queue.json"
+        queue_file.write_text(json.dumps(QUEUE_TEMPLATE, ensure_ascii=False))
+        result = run_done(queue_file)
+        assert result.returncode == 0, result.stderr
+        assert "OK: task-a → DONE" in result.stdout
+        assert "未コミットの変更" not in result.stderr


### PR DESCRIPTION
## 概要

学習ループ監査（2026-08-08）で特定した最大の欠落「書き出したルールが行動を変えたかを測る仕組みがない」に対し、効果検証（再発カウント→verified自動遷移）と機械化ゲート（enforcement: code）を導入する。

## 関連Issue

<!-- 本PRは監査起点の提案（docs/spec/learning-loop-verification-proposal.md）による。対応する既存Issueなし。sprint-27由来の教訓 #155/#156/#158/#159/#160 の恒久対策を含む -->

## 変更内容

- **提案書**: `docs/spec/learning-loop-verification-proposal.md`（v2、Sora QAレビューの指摘10件を反映）
- **Level 0 — 再発チェック基盤**
  - `scripts/lessons.sh`: `--recurrence-condition` 必須ゲート（failure かつ priority>=3）、`--enforcement` / `--source-repo` オプション、SSH→HTTPS 正規化、`verify-check` サブコマンド（再発なし2スプリント連続で `verified` 自動遷移／再発時は streak リセット＋verified 差し戻し）。エラーが exit 0 に化ける既存ディスパッチバグも修正
  - `docs/spec/lessons-json-schema.md`: 効果検証4フィールド追加＋実装済みフィールド（status/scope/stack/source_repo）の文書反映（v1.1.0）
  - `.claude/agents/retro.md`: ステップ2.7（前スプリントルールの再発チェック）新設、記録時の recurrence_condition / enforcement 必須化、メタ評価ルール（全軸PASS×priority>=6×2件→ルーブリック改訂提案、sprint-30まで試験運用）
- **Level 1 — 機械化ゲート**
  - `scripts/audit-scan.sh`: 自身の `readlink -f` 依存を python3 realpath へ修正した上で、readlink -f 非移植性チェック（3.7）を新設
  - `scripts/queue.py`: done 時の未コミット差分警告（repoルート明示解決・非ブロック）
  - `retro.md` ステップ5 / `scripts/propose-lesson-rules.sh`: `enforcement: code` の教訓はプロンプト書き出しをスキップ（二重管理防止）

## Test plan

- [x] pytest 全148件パス（新規22件含む: `tests/test_lessons_verify.py`, `tests/test_queue_done_git_guard.py`）
- [x] verify-check の streak 加算 → verified 遷移 → 再発リセット → verified 差し戻しの全遷移をユニットテストで確認
- [x] sprint-27 実教訓5件のフィクスチャでエンドツーエンド実証（sprint-28/29 想定で 4件 verified・1件機械化候補）
- [x] audit-scan.sh 3.7 のネガティブテスト（違反ファイル設置で FAIL・exit 1 を確認）
- [x] `bash -n` による構文チェック（lessons.sh / audit-scan.sh / propose-lesson-rules.sh）

## チェックリスト

- [x] 関連Issueの番号を記載した（対応Issueなし・提案書起点である旨を明記）
- [x] `gh issue close` などの直接API呼び出しは使用していない（クローズはPRマージで行う）
- [x] QA承認済み（Sora の条件付き承認 → 指摘10件を反映済み、全テストパス）
- [ ] ブランチ名が `feat/` または `fix/` で始まっている（セッション指定ブランチ `claude/claude-latest-info-h2f6o0` を使用）
- [x] Test plan の全項目がチェック済みである

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QnvMDh5bXUKhyBYEXWrjuY

---
_Generated by [Claude Code](https://claude.ai/code/session_01QnvMDh5bXUKhyBYEXWrjuY)_