### PR TITLE
feat(dashboard): サブエージェント別トークン集計を実装

### DIFF
--- a/dashboard/app/index.html
+++ b/dashboard/app/index.html
@@ -363,7 +363,7 @@ const LINES = {
 const ST_LBL = { idle:'IDLE', think:'THINK', work:'RUN', wait:'HOLD', done:'DONE' };
 const state = {
   agents: AGENTS.map(a => ({ ...a, st:'idle', task:null, done:0, tok:0, waitT:0, lastEventAt:0 })),
-  feed: [], clock: nowMinutes(), tokens: { hq:0, product:0, invest:0 }, doneTotal: 0,
+  feed: [], clock: nowMinutes(), tokens: { hq:0, product:0, invest:0 }, personaTokens: {}, doneTotal: 0,
   queueSprint: null, queueTasks: [], wsConnected: false,
 };
 const byId = Object.fromEntries(state.agents.map(a => [a.id, a]));
@@ -514,6 +514,16 @@ function applyTokens(depts){
   state.tokens.product = (depts.product && depts.product.total) || 0;
   state.tokens.invest = (depts.invest && depts.invest.total) || 0;
 }
+// サブエージェント個別のトークン消費（discovery.pyがagent-*.jsonlを発見できた分のみ値が入る。
+// 発見前=そのサブエージェントtranscriptがアクティブウィンドウ内に一度も書き込まれていない
+// 間はカード上0kのまま）を state.agents[].tok に同期する。
+function applyPersonaTokens(personas){
+  personas = personas || {};
+  state.personaTokens = personas;
+  for (const a of state.agents){
+    a.tok = (personas[a.id] && personas[a.id].total) || 0;
+  }
+}
 function applyQueue(queue){
   queue = queue || {};
   state.queueSprint = queue.sprint || null;
@@ -552,6 +562,7 @@ function connectWs(){
         // 逆に {"type":"tokens","depts":{...}} と depts キー配下に入るため、
         // ここは実装済みサーバの形に合わせる。
         if (msg.tokens) applyTokens(msg.tokens);
+        if (msg.personas) applyPersonaTokens(msg.personas);
         if (msg.queue) applyQueue(msg.queue);
         renderAll();
         break;
@@ -561,6 +572,7 @@ function connectWs(){
         break;
       case 'tokens':
         applyTokens(msg.depts);
+        applyPersonaTokens(msg.personas);
         renderAll();
         break;
       case 'queue':

--- a/dashboard/server/discovery.py
+++ b/dashboard/server/discovery.py
@@ -21,7 +21,7 @@ from pathlib import Path
 from typing import Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
-from enrich import department_for  # noqa: E402
+from enrich import department_for, persona_for  # noqa: E402
 
 # cwd 抽出のために transcript の末尾から読むバイト数。
 # 1行あたり通常は数KB以内に収まるため、直近数行を確実に拾える余裕を持たせている。
@@ -42,6 +42,9 @@ class ActiveSession:
     cwd: str
     dept: str
     mtime: float
+    # サブエージェント専用transcriptから発見した場合のみ設定する。メインセッション自身は
+    # 常に None（既存の挙動を変えないため）。
+    persona: Optional[str] = None
 
 
 def _extract_cwd(jsonl_path: Path) -> Optional[str]:
@@ -74,6 +77,74 @@ def _extract_cwd(jsonl_path: Path) -> Optional[str]:
         if isinstance(cwd, str) and cwd:
             return cwd
     return None
+
+
+def _read_agent_type(meta_path: Path) -> Optional[str]:
+    """agent-<id>.meta.json から agentType を取り出す。
+
+    サブエージェント専用transcriptにはメインセッションのような "cwd" フィールドが無いため、
+    persona解決には代わりにこの sidecar の agentType を使う。読めない・壊れている・
+    agentType が無い場合はクラッシュさせず None を返す（persona 未解決のまま登録される）。
+    """
+    try:
+        raw = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError, UnicodeDecodeError):
+        return None
+    if not isinstance(raw, dict):
+        return None
+    agent_type = raw.get("agentType")
+    return agent_type if isinstance(agent_type, str) and agent_type else None
+
+
+def _find_subagent_sessions(
+    session_jsonl_path: Path,
+    parent_session_id: str,
+    cwd: str,
+    dept: str,
+    active_within_seconds: float,
+    now: float,
+) -> list[ActiveSession]:
+    """<session_id>/subagents/agent-*.jsonl を探し、見つかった分だけ ActiveSession 化する。
+
+    サブディレクトリが存在しない（大半のセッションはサブエージェントを使わない）場合は
+    単に空リストを返す。
+    """
+    subagents_dir = session_jsonl_path.parent / session_jsonl_path.stem / "subagents"
+    if not subagents_dir.is_dir():
+        return []
+
+    try:
+        agent_jsonl_paths = list(subagents_dir.glob("agent-*.jsonl"))
+    except OSError as e:
+        _log(f"subagentsディレクトリ走査失敗（スキップ）: {subagents_dir}: {e}")
+        return []
+
+    sessions: list[ActiveSession] = []
+    for agent_jsonl_path in agent_jsonl_paths:
+        try:
+            mtime = agent_jsonl_path.stat().st_mtime
+        except OSError as e:
+            _log(f"stat失敗（スキップ）: {agent_jsonl_path}: {e}")
+            continue
+        # サブエージェント自身のtranscriptが直近active_within_seconds秒以内に更新されて
+        # いない限り、そのカードのトークンには一切反映されない（発見の前提条件）。
+        if now - mtime > active_within_seconds:
+            continue
+
+        meta_path = agent_jsonl_path.with_name(agent_jsonl_path.stem + ".meta.json")
+        agent_type = _read_agent_type(meta_path)
+        persona = persona_for({"agent_type": agent_type}) if agent_type else None
+
+        sessions.append(ActiveSession(
+            transcript_path=str(agent_jsonl_path),
+            session_id=f"{parent_session_id}/{agent_jsonl_path.stem}",
+            cwd=cwd,
+            dept=dept,
+            mtime=mtime,
+            persona=persona,
+        ))
+
+    return sessions
 
 
 def find_active_sessions(
@@ -123,12 +194,16 @@ def find_active_sessions(
             if cwd is None:
                 continue
 
+            dept = department_for(cwd)
             sessions.append(ActiveSession(
                 transcript_path=str(jsonl_path),
                 session_id=jsonl_path.stem,
                 cwd=cwd,
-                dept=department_for(cwd),
+                dept=dept,
                 mtime=mtime,
+            ))
+            sessions.extend(_find_subagent_sessions(
+                jsonl_path, jsonl_path.stem, cwd, dept, active_within_seconds, now,
             ))
 
     return sessions

--- a/dashboard/server/server.py
+++ b/dashboard/server/server.py
@@ -17,8 +17,11 @@ server.py — STONEFISH ダッシュボードのイベント受信サーバ
   cwd があれば承認キュー監視対象に登録する。
 - GET  /ws     : WebSocket。接続直後に直近200件のイベント・トークン集計・承認キューの
   現在状態を
-  {"type":"init", "events":[...], "tokens":{...}, "queue":{...}, "queues":{...}, "pending":[...]}
-  で送り、以後 live 配信する。`queue`（単数）は直近アクティブなプロジェクト1件分で、
+  {"type":"init", "events":[...], "tokens":{...}, "personas":{...}, "queue":{...},
+   "queues":{...}, "pending":[...]}
+  で送り、以後 live 配信する。`personas`は部門別`tokens`の兄弟キーで、サブエージェント
+  transcriptから解決できたペルソナ別のトークン集計（discovery.pyがsubagents/配下を発見
+  できた場合のみ値が入る）。`queue`（単数）は直近アクティブなプロジェクト1件分で、
   既存SPA（dashboard/app/index.html）との後方互換のために維持している。`queues`（複数、
   ラベル→キューのdict）は複数プロジェクトを横断表示したい将来のSPA拡張向けに追加した。
 - GET  /health : 死活監視用 {"ok": true, "clients": N, "events": N}
@@ -30,7 +33,7 @@ POLL_INTERVAL_SEC 周期で以下を行い、変化があれば全 WS クライ�
   transcript をトークン集計器・承認キュー監視対象に自動登録する（hooks配線不要）。発見した
   セッションのうち最も新しく更新された transcript のプロジェクトを「直近アクティブな
   プロジェクト」として `queue`（単数）に反映する
-- トークン集計器の poll() が True を返せば {"type":"tokens","depts":{...}}
+- トークン集計器の poll() が True を返せば {"type":"tokens","depts":{...},"personas":{...}}
 - 監視中のいずれかの `_queue.json` の mtime が変化していれば、
   {"type":"queue","queue":{...}}（直近アクティブなプロジェクト1件、既存SPA向け）と
   {"type":"queues","queues":{<label>: {...}, ...}}（既知の全プロジェクト分）の両方を配信する
@@ -279,7 +282,7 @@ def _discover_and_register(app: web.Application) -> list[ActiveSession]:
         return []
 
     for session in sessions:
-        aggregator.register(session.transcript_path, session.dept)
+        aggregator.register(session.transcript_path, session.dept, session.persona)
         _register_queue_target(queue_states, session.cwd)
 
     if sessions:
@@ -367,6 +370,7 @@ async def handle_ws(request: web.Request) -> web.WebSocketResponse:
                 "type": "init",
                 "events": store.recent(INIT_EVENT_COUNT),
                 "tokens": aggregator.totals(),
+                "personas": aggregator.persona_totals(),
                 "queue": _primary_queue(request.app),
                 "queues": _all_queues(queue_states),
                 "pending": [_pending_to_dict(p) for p in pending_list],
@@ -437,7 +441,11 @@ async def _background_poll_task(app: web.Application) -> None:
 
         try:
             if aggregator.poll():
-                await _broadcast(clients, {"type": "tokens", "depts": aggregator.totals()})
+                await _broadcast(clients, {
+                    "type": "tokens",
+                    "depts": aggregator.totals(),
+                    "personas": aggregator.persona_totals(),
+                })
         except Exception as e:
             # ポーリングの1周期での失敗でループ自体は止めない
             _log(f"トークン集計ポーリング中にエラー: {e}")

--- a/dashboard/server/tokens.py
+++ b/dashboard/server/tokens.py
@@ -58,14 +58,16 @@ class TranscriptAggregator:
 
     def __init__(self) -> None:
         self._depts: dict[str, str] = {}  # transcript_path -> dept
+        self._personas: dict[str, Optional[str]] = {}  # transcript_path -> persona（無ければNone）
         self._offsets: dict[str, int] = {}  # transcript_path -> 次回読み出し開始バイト位置
-        # message.id -> (最新timestamp, (input, output, cache), dept)
-        # dept は「その message.id を記録した時点の transcript の所属部門」を保持する。
-        self._entries: dict[str, tuple[datetime, tuple[int, int, int], str]] = {}
+        # message.id -> (最新timestamp, (input, output, cache), dept, persona)
+        # dept/persona は「その message.id を記録した時点の transcript の所属」を保持する。
+        self._entries: dict[str, tuple[datetime, tuple[int, int, int], str, Optional[str]]] = {}
 
-    def register(self, transcript_path: str, dept: str) -> None:
-        """監視対象の transcript を追加する。既知の path は dept のみ更新する（オフセットは維持）。"""
+    def register(self, transcript_path: str, dept: str, persona: Optional[str] = None) -> None:
+        """監視対象の transcript を追加する。既知の path は dept/persona のみ更新する（オフセットは維持）。"""
         self._depts[transcript_path] = dept
+        self._personas[transcript_path] = persona
         self._offsets.setdefault(transcript_path, 0)
 
     def poll(self) -> bool:
@@ -79,6 +81,7 @@ class TranscriptAggregator:
     def _poll_one(self, transcript_path: str) -> bool:
         offset = self._offsets[transcript_path]
         dept = self._depts.get(transcript_path, DEFAULT_DEPARTMENT)
+        persona = self._personas.get(transcript_path)
 
         try:
             with open(transcript_path, "rb") as fh:
@@ -126,20 +129,39 @@ class TranscriptAggregator:
             totals = _usage_totals(usage)
             existing = self._entries.get(message_id)
             if existing is None or ts > existing[0]:
-                self._entries[message_id] = (ts, totals, dept)
+                self._entries[message_id] = (ts, totals, dept, persona)
                 changed = True
 
         self._offsets[transcript_path] = offset + consumed
         return changed
 
     def totals(self) -> dict:
-        """id→(ts, totals, dept) の全エントリから部門別合計を再計算して返す。
+        """id→(ts, totals, dept, persona) の全エントリから部門別合計を再計算して返す。
 
         {"product": {"input": N, "output": N, "cache": N, "total": N}, ...}
         """
         result: dict[str, dict[str, int]] = {}
-        for _ts, (input_tokens, output_tokens, cache_tokens), dept in self._entries.values():
+        for _ts, (input_tokens, output_tokens, cache_tokens), dept, _persona in self._entries.values():
             bucket = result.setdefault(dept, {"input": 0, "output": 0, "cache": 0, "total": 0})
+            bucket["input"] += input_tokens
+            bucket["output"] += output_tokens
+            bucket["cache"] += cache_tokens
+            bucket["total"] += input_tokens + output_tokens + cache_tokens
+        return result
+
+    def persona_totals(self) -> dict:
+        """id→(ts, totals, dept, persona) の全エントリから persona 別合計を再計算して返す。
+
+        persona が解決できていない（None の）エントリは集計対象外にする
+        （メインセッション自身のtranscriptなど、サブエージェント以外の消費分はここに出さない）。
+
+        {"riku": {"input": N, "output": N, "cache": N, "total": N}, ...}
+        """
+        result: dict[str, dict[str, int]] = {}
+        for _ts, (input_tokens, output_tokens, cache_tokens), _dept, persona in self._entries.values():
+            if persona is None:
+                continue
+            bucket = result.setdefault(persona, {"input": 0, "output": 0, "cache": 0, "total": 0})
             bucket["input"] += input_tokens
             bucket["output"] += output_tokens
             bucket["cache"] += cache_tokens

--- a/tests/test_dashboard_discovery.py
+++ b/tests/test_dashboard_discovery.py
@@ -124,3 +124,115 @@ def test_directory_scan_io_error_does_not_crash(tmp_path, monkeypatch):
     # 単純に正常系が例外を出さないことを確認する（IO異常系はdiscovery内でtry/exceptしている）。
     sessions = find_active_sessions(tmp_path, active_within_seconds=600)
     assert len(sessions) == 1
+
+
+# ---------- サブエージェント専用transcriptの発見 ----------
+
+
+def _write_subagent(session_dir: Path, agent_id: str, meta: dict | None = "OMIT") -> Path:
+    """<session_dir>/subagents/agent-<agent_id>.jsonl (+.meta.json) を組み立てる。
+
+    meta=None で .meta.json 自体を作らないケース、meta={不正な形}で壊れたJSON等を
+    シミュレートできる。既定の "OMIT" センチネルは「正常なmetaを書く」を意味する。
+    """
+    subagents_dir = session_dir / "subagents"
+    subagents_dir.mkdir(parents=True, exist_ok=True)
+    agent_jsonl = subagents_dir / f"agent-{agent_id}.jsonl"
+    agent_jsonl.write_text(
+        json.dumps({
+            "message": {"role": "assistant", "id": f"msg_{agent_id}",
+                        "usage": {"input_tokens": 1, "output_tokens": 1}},
+            "timestamp": "2026-08-02T00:00:00.000Z",
+        }) + "\n",
+        encoding="utf-8",
+    )
+    if meta is None:
+        pass  # .meta.json を作らない
+    elif meta == "OMIT":
+        (subagents_dir / f"agent-{agent_id}.meta.json").write_text(
+            json.dumps({"agentType": "engineer-go", "description": "d", "name": "n"}),
+            encoding="utf-8",
+        )
+    else:
+        (subagents_dir / f"agent-{agent_id}.meta.json").write_text(meta, encoding="utf-8")
+    return agent_jsonl
+
+
+def test_finds_subagent_transcript_alongside_main_session(tmp_path):
+    project_dir = tmp_path / "-Users-x-agent-crew"
+    project_dir.mkdir()
+    main_transcript = project_dir / "session-1.jsonl"
+    _write_transcript(main_transcript, "/Users/x/Workspace/agent-crew")
+
+    session_dir = project_dir / "session-1"
+    agent_jsonl = _write_subagent(session_dir, "abc123")
+
+    sessions = find_active_sessions(tmp_path, active_within_seconds=600)
+    assert len(sessions) == 2
+
+    main = next(s for s in sessions if s.transcript_path == str(main_transcript))
+    assert main.persona is None
+
+    sub = next(s for s in sessions if s.transcript_path == str(agent_jsonl))
+    assert sub.persona == "riku"  # agentType "engineer-go" -> persona "riku"
+    assert sub.cwd == main.cwd == "/Users/x/Workspace/agent-crew"
+    assert sub.dept == main.dept == "product"
+
+
+def test_subagent_missing_meta_json_registers_with_persona_none(tmp_path):
+    project_dir = tmp_path / "-Users-x-agent-crew"
+    project_dir.mkdir()
+    main_transcript = project_dir / "session-1.jsonl"
+    _write_transcript(main_transcript, "/Users/x/Workspace/agent-crew")
+
+    session_dir = project_dir / "session-1"
+    agent_jsonl = _write_subagent(session_dir, "no-meta", meta=None)
+
+    sessions = find_active_sessions(tmp_path, active_within_seconds=600)
+    sub = next(s for s in sessions if s.transcript_path == str(agent_jsonl))
+    assert sub.persona is None
+
+
+def test_subagent_malformed_meta_json_registers_with_persona_none(tmp_path):
+    project_dir = tmp_path / "-Users-x-agent-crew"
+    project_dir.mkdir()
+    main_transcript = project_dir / "session-1.jsonl"
+    _write_transcript(main_transcript, "/Users/x/Workspace/agent-crew")
+
+    session_dir = project_dir / "session-1"
+    agent_jsonl = _write_subagent(session_dir, "broken", meta="{not valid json")
+
+    sessions = find_active_sessions(tmp_path, active_within_seconds=600)
+    sub = next(s for s in sessions if s.transcript_path == str(agent_jsonl))
+    assert sub.persona is None
+
+
+def test_subagent_dir_absent_is_normal_case_and_still_returns_main_session(tmp_path):
+    """subagents/ ディレクトリが無い（大半のケース）でも、これまで通りメインセッション
+    だけが返ること（回帰確認）。"""
+    project_dir = tmp_path / "-Users-x-agent-crew"
+    project_dir.mkdir()
+    main_transcript = project_dir / "session-1.jsonl"
+    _write_transcript(main_transcript, "/Users/x/Workspace/agent-crew")
+
+    sessions = find_active_sessions(tmp_path, active_within_seconds=600)
+    assert len(sessions) == 1
+    assert sessions[0].persona is None
+
+
+def test_stale_subagent_transcript_is_excluded_by_its_own_mtime(tmp_path):
+    project_dir = tmp_path / "-Users-x-agent-crew"
+    project_dir.mkdir()
+    main_transcript = project_dir / "session-1.jsonl"
+    _write_transcript(main_transcript, "/Users/x/Workspace/agent-crew")
+
+    session_dir = project_dir / "session-1"
+    agent_jsonl = _write_subagent(session_dir, "stale")
+    old_time = time.time() - 3600
+    import os
+    os.utime(agent_jsonl, (old_time, old_time))
+
+    sessions = find_active_sessions(tmp_path, active_within_seconds=600)
+    assert all(s.transcript_path != str(agent_jsonl) for s in sessions)
+    # メインセッションは引き続き見つかる
+    assert any(s.transcript_path == str(main_transcript) for s in sessions)

--- a/tests/test_dashboard_server.py
+++ b/tests/test_dashboard_server.py
@@ -170,6 +170,7 @@ async def test_ws_init_includes_tokens_queues_and_pending_defaults(aiohttp_clien
     init_msg = await ws.receive_json()
     assert init_msg["type"] == "init"
     assert init_msg["tokens"] == {}
+    assert init_msg["personas"] == {}
     assert init_msg["queue"] == {"tasks": []}
     assert init_msg["queues"] == {}
     assert init_msg["pending"] == []
@@ -258,6 +259,7 @@ async def test_background_poll_broadcasts_tokens_and_queue(aiohttp_client, tmp_p
     assert "tokens" in seen
     assert seen["tokens"]["depts"]["other"]["input"] == 10
     assert seen["tokens"]["depts"]["other"]["output"] == 5
+    assert seen["tokens"]["personas"] == {}  # persona未解決（メインセッション）分は載らない
 
     label = project_dir.name  # "myproj"
     expected_tasks = [{"slug": "t1", "title": "Task 1", "status": "TODO", "assigned_to": "Riku"}]
@@ -374,6 +376,54 @@ async def test_discovery_finds_session_without_any_hooks_or_post_events(aiohttp_
     assert init_msg["queues"]["agent-crew"]["tasks"][0]["slug"] == "t1"
     # 唯一のアクティブセッションなので、既存SPA向けの単数 "queue" にも同じ内容が入る
     assert init_msg["queue"]["tasks"][0]["slug"] == "t1"
+
+    await ws.close()
+
+
+async def test_discovery_finds_subagent_transcript_and_reports_persona_totals(
+    aiohttp_client, tmp_path, monkeypatch
+):
+    """discovery.py がサブエージェント専用transcript（agent-*.jsonl + .meta.json）を発見した
+    場合、init メッセージの "personas" にペルソナ別トークン集計が載ること。"""
+    projects_root = tmp_path / "claude-projects"
+    project_encoded_dir = projects_root / "-Users-x-agent-crew"
+    project_encoded_dir.mkdir(parents=True)
+
+    real_project_dir = tmp_path / "agent-crew"
+    real_project_dir.mkdir(parents=True)
+
+    main_transcript = project_encoded_dir / "session-1.jsonl"
+    _write_transcript_with_cwd(main_transcript, str(real_project_dir))
+
+    subagents_dir = project_encoded_dir / "session-1" / "subagents"
+    subagents_dir.mkdir(parents=True)
+    (subagents_dir / "agent-abc.jsonl").write_text(
+        json.dumps({
+            "message": {
+                "role": "assistant",
+                "id": "msg_sub",
+                "usage": {"input_tokens": 3, "output_tokens": 4,
+                          "cache_creation_input_tokens": 0, "cache_read_input_tokens": 0},
+            },
+            "timestamp": "2026-08-02T00:00:00.000Z",
+        }) + "\n",
+        encoding="utf-8",
+    )
+    (subagents_dir / "agent-abc.meta.json").write_text(
+        json.dumps({"agentType": "engineer-go", "description": "d", "name": "n"}),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(server_module, "PROJECTS_ROOT", projects_root)
+
+    test_app = server_module.build_app(tmp_path / "data")
+    client = await aiohttp_client(test_app)
+    ws = await client.ws_connect("/ws")
+    init_msg = await ws.receive_json()
+
+    assert init_msg["type"] == "init"
+    assert init_msg["personas"]["riku"]["input"] == 3
+    assert init_msg["personas"]["riku"]["output"] == 4
 
     await ws.close()
 

--- a/tests/test_dashboard_tokens.py
+++ b/tests/test_dashboard_tokens.py
@@ -231,6 +231,88 @@ def test_cache_tokens_combine_creation_and_read(tmp_path):
     assert agg.totals()["product"]["cache"] == 150
 
 
+# ---------- persona 別集計 ----------
+
+
+def test_persona_totals_aggregates_registered_persona(tmp_path):
+    transcript = tmp_path / "agent-1.jsonl"
+    transcript.write_text(
+        _usage_line("msg_1", "2026-08-01T10:00:00.000Z", input_tokens=10, output_tokens=1) + "\n",
+        encoding="utf-8",
+    )
+
+    agg = TranscriptAggregator()
+    agg.register(str(transcript), "product", persona="riku")
+    agg.poll()
+
+    persona_totals = agg.persona_totals()
+    assert persona_totals["riku"]["input"] == 10
+    assert persona_totals["riku"]["output"] == 1
+    assert persona_totals["riku"]["total"] == 11
+    # totals()（部門別）の出力形は変わっていないこと（回帰確認）
+    assert agg.totals()["product"]["total"] == 11
+
+
+def test_persona_totals_excludes_entries_with_persona_none(tmp_path):
+    with_persona = tmp_path / "agent-1.jsonl"
+    without_persona = tmp_path / "session.jsonl"
+    with_persona.write_text(
+        _usage_line("msg_p", "2026-08-01T10:00:00.000Z", input_tokens=5, output_tokens=1) + "\n",
+        encoding="utf-8",
+    )
+    without_persona.write_text(
+        _usage_line("msg_np", "2026-08-01T10:00:00.000Z", input_tokens=100, output_tokens=1) + "\n",
+        encoding="utf-8",
+    )
+
+    agg = TranscriptAggregator()
+    agg.register(str(with_persona), "product", persona="sora")
+    agg.register(str(without_persona), "product")  # persona未指定 = None
+    agg.poll()
+
+    persona_totals = agg.persona_totals()
+    assert set(persona_totals.keys()) == {"sora"}
+    assert persona_totals["sora"]["total"] == 6
+
+
+def test_persona_totals_combines_multiple_files_for_same_persona(tmp_path):
+    t1 = tmp_path / "agent-1.jsonl"
+    t2 = tmp_path / "agent-2.jsonl"
+    t1.write_text(
+        _usage_line("msg_1", "2026-08-01T10:00:00.000Z", input_tokens=10, output_tokens=1) + "\n",
+        encoding="utf-8",
+    )
+    t2.write_text(
+        _usage_line("msg_2", "2026-08-01T10:00:00.000Z", input_tokens=20, output_tokens=2) + "\n",
+        encoding="utf-8",
+    )
+
+    agg = TranscriptAggregator()
+    agg.register(str(t1), "product", persona="riku")
+    agg.register(str(t2), "invest", persona="riku")
+    agg.poll()
+
+    persona_totals = agg.persona_totals()
+    assert persona_totals["riku"]["input"] == 30
+    assert persona_totals["riku"]["output"] == 3
+
+
+def test_persona_totals_deduplicates_by_message_id(tmp_path):
+    """message.id 重複排除（ストリーミング途中経過の合算防止）が persona 集計でも効くこと。"""
+    transcript = tmp_path / "agent-1.jsonl"
+    lines = [
+        _usage_line("msg_1", "2026-08-01T10:00:00.000Z", input_tokens=5, output_tokens=1),
+        _usage_line("msg_1", "2026-08-01T10:00:01.000Z", input_tokens=5, output_tokens=9),
+    ]
+    transcript.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    agg = TranscriptAggregator()
+    agg.register(str(transcript), "product", persona="riku")
+    agg.poll()
+
+    assert agg.persona_totals()["riku"]["output"] == 9
+
+
 # ---------- 実データ検証（Sprint-24 教訓: ストリーミングJSONLは実データ確認必須） ----------
 
 


### PR DESCRIPTION
## 概要

「エージェントカード個別のトークン表示が常に0kのまま」という指摘への対応。原因を追うと2段階あった。

1. 表面的な原因: サーバが部門合計しか配信しておらず、SPA側にも個別反映のロジックが無かった
2. **より根本的な発見**: ADR-016 以降の主経路 `discovery.py` は各プロジェクトの**メインセッション transcript しかスキャンしておらず**、サブエージェント専用の transcript（`<session>/subagents/agent-*.jsonl`）を一切発見していなかった。つまりこれまで**部門合計にもサブエージェントの消費が計上されていなかった**（実データで確認・本PRで解消）

## 実装

- `discovery.py`: `ActiveSession` に `persona` を追加。メインセッションと同名ディレクトリの `subagents/` 配下を列挙し、`agent-*.meta.json` の `agentType` を `enrich.persona_for()` で解決してサブエージェント分の `ActiveSession` も生成する。`meta.json` 欠落・破損時は `persona=None` にフォールバックしクラッシュしない
- `tokens.py`: `register()` に `persona` 引数を追加（既定 None、後方互換）。新規 `persona_totals()`。`totals()`（部門別）の出力形は不変
- `server.py`: init/tokens の両WSメッセージに `personas` を兄弟キーとして追加
- `app/index.html`: `personas` を受けて各エージェントカードの `a.tok` に同期する `applyPersonaTokens()` を追加

## 既知の制約

サブエージェントのカードにトークンが反映されるのは、そのサブエージェントの transcript ファイルがアクティブウィンドウ（600秒）以内に発見された後。実行完了直後〜10分は反映が遅れうる。

## Test Plan

- [x] `uv run --group dashboard pytest tests/` 158件全パス（新規10件: discovery 5件 / tokens 4件 / server 1件）
- [x] 実データ検証: 直前に走っていたサブエージェント（riku-persona-tokens、本PR自体の実装作業）の消費が `personas.riku` に約337万トークンとして正しく計上されることを一時サーバ（別ポート・別データディレクトリ、本番には非干渉）で確認
- [x] 副作用確認: transcript ファイルが物理的に別なので dept 合計との二重計上なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RaUuTfTDryzX6iBE5teCYY